### PR TITLE
Run `make manifests` as part of code generation on Wercker

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -29,6 +29,9 @@ generate:
         name: Generate code
         code: make generate
     - script:
+        name: Generate manifests
+        code: make manifests
+    - script:
         name: Check git tree is clean
         code: if [[ ! -z $(git status -s) ]]; then git status; exit 1; fi
 


### PR DESCRIPTION
It wasn't included before, but should be.