### PR TITLE
Double linting deadline

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -56,7 +56,8 @@ lint:
        --enable=deadcode \
        --enable=gofmt \
        --enable=goimports \
-       --tests ./...
+       --tests ./... \
+       --deadline=60s
 
 test:
   steps:


### PR DESCRIPTION
Linting keeps failing on wercker, perhaps we should up the timeout? (Default of `30s`)