### PR TITLE
Use Ginkgo CLI on Wercker

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -64,6 +64,10 @@ test:
   - wercker/setup-go-workspace:
       package-dir: github.com/pusher/faros
   - script:
+    name: Install Ginkgo CLI
+    code: |
+      go get -u github.com/onsi/ginkgo/ginkgo
+  - script:
       name: Setup Test environment
       code: |
         export TEST_ASSET_DIR=/usr/local/bin
@@ -80,8 +84,8 @@ test:
         chmod +x $TEST_ASSET_KUBE_APISERVER
         chmod +x $TEST_ASSET_KUBECTL
   - script:
-      name: go test
-      code: go test ./pkg/... ./cmd/...
+      name: ginkgo
+      code: ginkgo -v -race -randomizeAllSpecs ./pkg/... ./cmd/...
 
 build:
   steps:


### PR DESCRIPTION
The CLI has some nice features such as running the tests in a random order each time (to discover tests that depend on each other, or don't clean up after themselves), and I prefer the output it produces (reminds me of RSpec :).