### PR TITLE
Filter reconcile requests by namespace

### DIFF
--- a/pkg/controller/gittrack/gittrack_controller.go
+++ b/pkg/controller/gittrack/gittrack_controller.go
@@ -83,7 +83,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to GitTrack
-	err = c.Watch(&source.Kind{Type: &farosv1alpha1.GitTrack{}}, &handler.EnqueueRequestForObject{}, &NamespacedPredicate{
+	err = c.Watch(&source.Kind{Type: &farosv1alpha1.GitTrack{}}, &handler.EnqueueRequestForObject{}, &utils.NamespacedPredicate{
 		Namespace: *namespace,
 	})
 	if err != nil {

--- a/pkg/utils/predicate.go
+++ b/pkg/utils/predicate.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package gittrack
+package utils
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/event"

--- a/pkg/utils/predicate_test.go
+++ b/pkg/utils/predicate_test.go
@@ -1,13 +1,29 @@
-package gittrack
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
 
 import (
 	"testing"
 
+	"github.com/kubernetes-sigs/kubebuilder/pkg/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	"github.com/kubernetes-sigs/kubebuilder/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -16,31 +32,26 @@ func TestNamespacedPredicate(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, "NamespacedPredicate Suite", []Reporter{test.NewlineReporter{}})
 }
 
-var predicate NamespacedPredicate
-var matchingObjectMeta = &metav1.ObjectMeta{
-	Name:      "example",
-	Namespace: "predicate",
-}
-var mismatchObjectMeta = &metav1.ObjectMeta{
-	Name:      "example",
-	Namespace: "other",
-}
-var createEvent event.CreateEvent
-var updateEvent event.UpdateEvent
-var deleteEvent event.DeleteEvent
-var genericEvent event.GenericEvent
-
 var _ = Describe("NamespacedPredicate", func() {
+	var (
+		predicate    NamespacedPredicate
+		createEvent  event.CreateEvent
+		updateEvent  event.UpdateEvent
+		deleteEvent  event.DeleteEvent
+		genericEvent event.GenericEvent
+	)
+
 	BeforeEach(func() {
 		predicate = NamespacedPredicate{Namespace: "predicate"}
 	})
 
 	Context("When the namespace of the event matches the Predicate's", func() {
 		BeforeEach(func() {
-			createEvent = event.CreateEvent{Meta: matchingObjectMeta}
-			updateEvent = event.UpdateEvent{MetaNew: matchingObjectMeta}
-			deleteEvent = event.DeleteEvent{Meta: matchingObjectMeta}
-			genericEvent = event.GenericEvent{Meta: matchingObjectMeta}
+			matchingMeta := &metav1.ObjectMeta{Name: "example", Namespace: "predicate"}
+			createEvent = event.CreateEvent{Meta: matchingMeta}
+			updateEvent = event.UpdateEvent{MetaNew: matchingMeta}
+			deleteEvent = event.DeleteEvent{Meta: matchingMeta}
+			genericEvent = event.GenericEvent{Meta: matchingMeta}
 		})
 
 		Context("Create", func() {
@@ -70,10 +81,11 @@ var _ = Describe("NamespacedPredicate", func() {
 
 	Context("When the namespace of the event doesn't match the Predicate's", func() {
 		BeforeEach(func() {
-			createEvent = event.CreateEvent{Meta: mismatchObjectMeta}
-			updateEvent = event.UpdateEvent{MetaNew: mismatchObjectMeta}
-			deleteEvent = event.DeleteEvent{Meta: mismatchObjectMeta}
-			genericEvent = event.GenericEvent{Meta: mismatchObjectMeta}
+			mismatchMeta := &metav1.ObjectMeta{Name: "example", Namespace: "other"}
+			createEvent = event.CreateEvent{Meta: mismatchMeta}
+			updateEvent = event.UpdateEvent{MetaNew: mismatchMeta}
+			deleteEvent = event.DeleteEvent{Meta: mismatchMeta}
+			genericEvent = event.GenericEvent{Meta: mismatchMeta}
 		})
 
 		Context("Create", func() {
@@ -104,6 +116,11 @@ var _ = Describe("NamespacedPredicate", func() {
 	Context("When the Predicate's namespace is the empty string", func() {
 		BeforeEach(func() {
 			predicate = NamespacedPredicate{Namespace: ""}
+			otherMeta := &metav1.ObjectMeta{Name: "example", Namespace: "other"}
+			createEvent = event.CreateEvent{Meta: otherMeta}
+			updateEvent = event.UpdateEvent{MetaNew: otherMeta}
+			deleteEvent = event.DeleteEvent{Meta: otherMeta}
+			genericEvent = event.GenericEvent{Meta: otherMeta}
 		})
 
 		Context("Create", func() {
@@ -133,7 +150,7 @@ var _ = Describe("NamespacedPredicate", func() {
 
 	Context("When the Events' namespace is the empty string", func() {
 		BeforeEach(func() {
-			emptyMeta := &metav1.ObjectMeta{Name: "example"}
+			emptyMeta := &metav1.ObjectMeta{Name: "example", Namespace: ""}
 			createEvent = event.CreateEvent{Meta: emptyMeta}
 			updateEvent = event.UpdateEvent{MetaNew: emptyMeta}
 			deleteEvent = event.DeleteEvent{Meta: emptyMeta}


### PR DESCRIPTION
The `GitTrack` controller now supports a `--namespace` flag which will make the controller only reconcile requests in the given namespace.

I do still want to add a test case to the controller test suite, with the motivation being that if we ever change the `Watch` call we don't have anything that verifies that the desired behaviour still works. Open to suggestions on how to test it properly.