### PR TITLE
Use controller runtime shared cache for child object informers

### DIFF
--- a/pkg/controller/gittrackobject/watch.go
+++ b/pkg/controller/gittrackobject/watch.go
@@ -19,16 +19,8 @@ package gittrackobject
 import (
 	"fmt"
 	"log"
-	"time"
 
-	"github.com/pusher/faros/pkg/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/informers/internalinterfaces"
-	"k8s.io/client-go/tools/cache"
 )
 
 // watch sets up an informer for the object kind and sends events to the
@@ -41,7 +33,7 @@ func (r *ReconcileGitTrackObject) watch(obj unstructured.Unstructured) error {
 
 	// Create new informer
 	log.Printf("Creating new informer for kind %s", obj.GetObjectKind().GroupVersionKind().Kind)
-	informer, err := r.newInformerFromObject(obj)
+	informer, err := r.cache.GetInformer(&obj)
 	if err != nil {
 		msg := fmt.Sprintf("error creating informer: %v", err)
 		log.Printf(msg)
@@ -55,63 +47,7 @@ func (r *ReconcileGitTrackObject) watch(obj unstructured.Unstructured) error {
 
 	// Store and run informer
 	r.informers[informerKey(obj)] = informer
-	go informer.Run(r.stop)
-
 	return nil
-}
-
-// newInformerFromObject takes an Unstructured object and builds a
-// SharedIndexInformer for the object's kind.
-func (r *ReconcileGitTrackObject) newInformerFromObject(obj unstructured.Unstructured) (cache.SharedIndexInformer, error) {
-	gvk := obj.GetObjectKind().GroupVersionKind()
-
-	// Get API Resource and namespaced
-	gvr, namespaced, err := utils.GetAPIResource(r.restMapper, gvk)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get API Resource: %v", err)
-	}
-
-	client, err := dynamic.NewForConfig(r.config)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create dynamic client: %v", err)
-	}
-	resourceClient := client.Resource(gvr).Namespace(resourceDefaultNamespace(namespaced, obj))
-
-	// Set up empty tweak options
-	tweakOptions := func(opts *metav1.ListOptions) {}
-
-	return newSharedIndexInformer(
-		resourceClient,
-		r.syncPeriod,
-		&unstructured.Unstructured{},
-		cache.Indexers{
-			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
-		},
-		tweakOptions,
-	), nil
-}
-
-// newSharedIndexInformer constructs a new SharedIndexInformer for the object.
-func newSharedIndexInformer(client dynamic.ResourceInterface, resyncPeriod time.Duration, objType runtime.Object, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
-		&cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				if tweakListOptions != nil {
-					tweakListOptions(&options)
-				}
-				return client.List(options)
-			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				if tweakListOptions != nil {
-					tweakListOptions(&options)
-				}
-				return client.Watch(options)
-			},
-		},
-		objType,
-		resyncPeriod,
-		indexers,
-	)
 }
 
 // informerKey creates a unique identifier containing the object's namespace,
@@ -120,13 +56,4 @@ func newSharedIndexInformer(client dynamic.ResourceInterface, resyncPeriod time.
 // This can be used to uniquely identify informers.
 func informerKey(obj unstructured.Unstructured) string {
 	return fmt.Sprintf("%s:%s", obj.GetNamespace(), obj.GroupVersionKind().String())
-}
-
-// resourceDefaultNamespace defaults to the item's namespace
-// but clears it for cluster scoped resources
-func resourceDefaultNamespace(namespaced bool, obj unstructured.Unstructured) string {
-	if namespaced {
-		return obj.GetNamespace()
-	}
-	return ""
 }


### PR DESCRIPTION
The informer cache now supports unstructured objects so it's simple to switch out for our own informer making routine.

Now we only have one cache so don't need to look up the sync period anymore as well