### PR TITLE
Fix error messages for events from test suite

### DIFF
--- a/pkg/controller/gittrack/gittrack_controller_test.go
+++ b/pkg/controller/gittrack/gittrack_controller_test.go
@@ -942,6 +942,7 @@ var getsFilesFromRepo = func(path string, count int) {
 			Expect(ok).To(BeTrue())
 			gt = &farosv1alpha1.GitTrack{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
 					Namespace: "default",
 				},
 				Spec: farosv1alpha1.GitTrackSpec{
@@ -951,8 +952,15 @@ var getsFilesFromRepo = func(path string, count int) {
 					Reference:  "4c31dbdd7103dc209c8bb21b75d78b3efafadc31",
 				},
 			}
+
+			Expect(c.Create(context.TODO(), gt)).NotTo(HaveOccurred())
+
 			files, err = reconciler.getFiles(gt)
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			Expect(c.Delete(context.TODO(), gt)).NotTo(HaveOccurred())
 		})
 
 		It("Filters files by SubPath", func() {


### PR DESCRIPTION
Event errors were being sent from within these test cases because the object didn't actually exist (It hadn't been created so didn't have all of the defaulting done)

By creating/deleting the object within each test the error has now gone away