### PR TITLE
Disable metrics while testing

### DIFF
--- a/pkg/controller/gittrack/gittrack_controller_suite_test.go
+++ b/pkg/controller/gittrack/gittrack_controller_suite_test.go
@@ -108,6 +108,7 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 func StartTestManager(mgr manager.Manager) chan struct{} {
 	stop := make(chan struct{})
 	go func() {
+		defer GinkgoRecover()
 		Expect(mgr.Start(stop)).NotTo(HaveOccurred())
 	}()
 	return stop

--- a/pkg/controller/gittrack/gittrack_controller_test.go
+++ b/pkg/controller/gittrack/gittrack_controller_test.go
@@ -94,7 +94,8 @@ var _ = Describe("GitTrack Suite", func() {
 		var err error
 		cfg.RateLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
 		mgr, err = manager.New(cfg, manager.Options{
-			Namespace: farosflags.Namespace,
+			Namespace:          farosflags.Namespace,
+			MetricsBindAddress: "0", // Disable serving metrics while testing
 		})
 		Expect(err).NotTo(HaveOccurred())
 		c = mgr.GetClient()

--- a/pkg/controller/gittrackobject/gittrackobject_controller_suite_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_suite_test.go
@@ -83,6 +83,7 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 func StartTestManager(mgr manager.Manager) chan struct{} {
 	stop := make(chan struct{})
 	go func() {
+		defer GinkgoRecover()
 		Expect(mgr.Start(stop)).NotTo(HaveOccurred())
 	}()
 	return stop

--- a/pkg/controller/gittrackobject/gittrackobject_controller_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_test.go
@@ -219,7 +219,8 @@ var _ = Describe("GitTrackObject Suite", func() {
 		var err error
 		cfg.RateLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
 		mgr, err = manager.New(cfg, manager.Options{
-			Namespace: "default",
+			Namespace:          "default",
+			MetricsBindAddress: "0", // Disable serving metrics while testing
 		})
 		Expect(err).NotTo(HaveOccurred())
 		c = mgr.GetClient()


### PR DESCRIPTION
I've periodically noticed that the test suite has been panicking. I added these ginkgo recovers which pointed me to where and why it was panicking.

I've disabled metric serving while testing since it was causing port clashes and panics.