### PR TITLE
Add metrics-bind-address flag

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -36,6 +36,7 @@ var (
 	leaderElection           = flag.Bool("leader-election", false, "Should the controller use leader election")
 	leaderElectionID         = flag.String("leader-election-id", "", "Name of the configmap used by the leader election system")
 	leaederElectionNamespace = flag.String("leader-election-namespace", "", "Namespace for the configmap used by the leader election system")
+	metricsBindAddress       = flag.String("metrics-bind-address", ":8080", "Specify which address to bind to for serving prometheus metrics")
 	syncPeriod               = flag.Duration("sync-period", 5*time.Minute, "Reconcile sync period")
 )
 
@@ -57,6 +58,7 @@ func main() {
 		LeaderElection:          *leaderElection,
 		LeaderElectionID:        *leaderElectionID,
 		LeaderElectionNamespace: *leaederElectionNamespace,
+		MetricsBindAddress:      *metricsBindAddress,
 		SyncPeriod:              syncPeriod,
 		Namespace:               farosflags.Namespace,
 	})


### PR DESCRIPTION
This flag should have been added when metrics were added.

This defaults to the same value that the `controller-runtime` does so shouldn't be a breaking change.