### PR TITLE
Divide time to deploy metric into sensible buckets

### DIFF
--- a/pkg/controller/gittrack/metrics/metrics.go
+++ b/pkg/controller/gittrack/metrics/metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -35,6 +37,22 @@ var (
 	TimeToDeploy = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "faros_gittrack_time_to_deploy_seconds",
 		Help: "Counts the time from commit to deploy of a child resource",
+		Buckets: []float64{
+			// Divide histogram into sensible buckets
+			1 * time.Minute.Seconds(), // Per minute up to 5 minutes
+			2 * time.Minute.Seconds(),
+			3 * time.Minute.Seconds(),
+			4 * time.Minute.Seconds(),
+			5 * time.Minute.Seconds(), // Per 5 minutes up to 30 minutes
+			10 * time.Minute.Seconds(),
+			15 * time.Minute.Seconds(),
+			20 * time.Minute.Seconds(),
+			25 * time.Minute.Seconds(),
+			30 * time.Minute.Seconds(), // Per 10 minutes up to an hour
+			40 * time.Minute.Seconds(),
+			50 * time.Minute.Seconds(),
+			1 * time.Hour.Seconds(), // +Inf after an hour
+		},
 	}, []string{"name", "namespace", "repository"})
 )
 


### PR DESCRIPTION
The time to deploy metric currently has buckets in divisions up to 10 seconds, everything over 10 seconds becomes a `+Inf`, this should help to make the metric more usable by dividing the histogram into more sensible buckets that should be realistic for time from merge to deploy