### PR TITLE
Set inSync true when update strategy set to never

### DIFF
--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -291,6 +291,8 @@ func (r *ReconcileGitTrackObject) Reconcile(request reconcile.Request) (reconcil
 
 	if updateStrategy == gittrackobjectutils.NeverUpdateStrategy {
 		log.Printf("Update strategy for %s set to never, ignoring", found.GetName())
+		// If we aren't updating the resource we should assume the resource is in sync
+		mOpts.inSync = true
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
Currently, the inSync metric is a bit useless since it doesn't distinguish between those which are ignored and those where an attempt has been made, but failed, to synchronise the child resource.

By assuming that the child is in sync when update strategy is never, we should be able to alert when an object is out of sync (ie all inSync metrics should equal 1 unless there is a problem)