### PR TITLE
Add AddToScheme to allow generated client to register faros types

### DIFF
--- a/pkg/apis/faros/v1alpha1/register.go
+++ b/pkg/apis/faros/v1alpha1/register.go
@@ -35,4 +35,7 @@ var (
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+
+	// AddToScheme is used to register the new types with the Scheme
+	AddToScheme = SchemeBuilder.AddToScheme
 )


### PR DESCRIPTION
This is required for #67 to actually be useable, the `scheme.Register` method expects this method to exist