### PR TITLE
Fix example manager.yaml, kustomization.yaml and add instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Faros is a [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) based
 project, as such we have auto-generated [CRDs](config/crds) and
 [Kustomize](https://github.com/kubernetes-sigs/kustomize) configuration as
 examples of how to install the controller in the [config](config) folder.
+To quickly install the controller and CRDs on a cluster you can run `make deploy`.
 
 You **must** manually install the [CRDs](config/crds) before the controller will
 be fully functional, it will not install them for you.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,8 +18,9 @@ namePrefix: faros-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../rbac/*.yaml
-- ../manager/*.yaml
+- ../rbac/rbac_role.yaml
+- ../rbac/rbac_role_binding.yaml
+- ../manager/manager.yaml
 
 patches:
 - manager_image_patch.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,8 +41,6 @@ spec:
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
-      - command:
-        - /root/manager
         image: controller:latest
         name: manager
         resources:


### PR DESCRIPTION
This PR does the following: 

- Fixes the example manager.yaml to use the default entrypoint of the image as the one provided doesn't exist in the latest image.
- Fix an issue when trying to use the latest version of kustomize that doesn't recognize paths like `../rbac/*.yaml`
- Adds a line to the README to indicate how to deploy/install with the provided Makefile. 