### PR TITLE
Replace gometalinter with golangci-lint

### DIFF
--- a/pkg/apis/faros/v1alpha1/gittrack_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrack_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/apis/faros/v1alpha1/gittrackobject_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrackobject_types.go
@@ -19,7 +19,7 @@ package v1alpha1
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/apis/faros/v1alpha1/interfaces.go
+++ b/pkg/apis/faros/v1alpha1/interfaces.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )

--- a/pkg/controller/gittrack/gittrack_controller_test.go
+++ b/pkg/controller/gittrack/gittrack_controller_test.go
@@ -36,7 +36,7 @@ import (
 	testutils "github.com/pusher/faros/test/utils"
 	gitstore "github.com/pusher/git-store"
 	"golang.org/x/net/context"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -58,6 +58,8 @@ var expectedRequest = reconcile.Request{NamespacedName: key}
 
 const timeout = time.Second * 5
 const filePathRegexp = "^[a-zA-Z0-9/\\-\\.]*\\.(?:yaml|yml|json)$"
+const doesNotExistPath = "does-not-exist"
+const repeatedReference = "448b39a21d285fcb5aa4b718b27a3e13ffc649b3"
 
 var _ = Describe("GitTrack Suite", func() {
 	var createInstance = func(gt *farosv1alpha1.GitTrack, ref string) {
@@ -306,7 +308,7 @@ var _ = Describe("GitTrack Suite", func() {
 
 		Context("with an invalid Reference", func() {
 			BeforeEach(func() {
-				createInstance(instance, "does-not-exist")
+				createInstance(instance, doesNotExistPath)
 				// Wait for client cache to expire
 				waitForInstanceCreated(key)
 			})
@@ -339,7 +341,7 @@ var _ = Describe("GitTrack Suite", func() {
 
 		Context("with an invalid SubPath", func() {
 			BeforeEach(func() {
-				instance.Spec.SubPath = "does-not-exist"
+				instance.Spec.SubPath = doesNotExistPath
 				createInstance(instance, "master")
 				// Wait for client cache to expire
 				waitForInstanceCreated(key)
@@ -407,7 +409,7 @@ var _ = Describe("GitTrack Suite", func() {
 							{
 								APIVersion:         "faros.pusher.com/v1alpha1",
 								Kind:               "GitTrack",
-								Name:               "does-not-exist",
+								Name:               doesNotExistPath,
 								UID:                "12345",
 								Controller:         &truth,
 								BlockOwnerDeletion: &truth,
@@ -587,7 +589,7 @@ var _ = Describe("GitTrack Suite", func() {
 					return c.Get(context.TODO(), types.NamespacedName{Name: "deployment-nginx", Namespace: "default"}, before)
 				}, timeout).Should(Succeed())
 
-				instance.Spec.Reference = "448b39a21d285fcb5aa4b718b27a3e13ffc649b3"
+				instance.Spec.Reference = repeatedReference
 				err := c.Update(context.TODO(), instance)
 				Expect(err).ToNot(HaveOccurred())
 				// Wait for reconcile for update
@@ -617,7 +619,7 @@ var _ = Describe("GitTrack Suite", func() {
 					return c.Get(context.TODO(), types.NamespacedName{Name: "service-nginx", Namespace: "default"}, before)
 				}, timeout).Should(Succeed())
 
-				instance.Spec.Reference = "448b39a21d285fcb5aa4b718b27a3e13ffc649b3"
+				instance.Spec.Reference = repeatedReference
 				err := c.Update(context.TODO(), instance)
 				Expect(err).ToNot(HaveOccurred())
 				// Wait for reconcile for update
@@ -634,7 +636,7 @@ var _ = Describe("GitTrack Suite", func() {
 
 			It("sends events about updating resources", func() {
 				Eventually(func() error { return c.Get(context.TODO(), key, instance) }, timeout).Should(Succeed())
-				instance.Spec.Reference = "448b39a21d285fcb5aa4b718b27a3e13ffc649b3"
+				instance.Spec.Reference = repeatedReference
 				Expect(c.Update(context.TODO(), instance)).ToNot(HaveOccurred())
 				// Wait for reconcile for update
 				Eventually(requests, timeout).Should(Receive(Equal(expectedRequest)))
@@ -673,7 +675,7 @@ var _ = Describe("GitTrack Suite", func() {
 				Expect(instance.Spec.Reference).To(Equal("a14443638218c782b84cae56a14f1090ee9e5c9c"))
 
 				// Update the reference
-				instance.Spec.Reference = "448b39a21d285fcb5aa4b718b27a3e13ffc649b3"
+				instance.Spec.Reference = repeatedReference
 				err := c.Update(context.TODO(), instance)
 				Expect(err).ToNot(HaveOccurred())
 				// Wait for reconcile for update
@@ -721,7 +723,7 @@ var _ = Describe("GitTrack Suite", func() {
 				}, timeout).Should(Succeed())
 				Eventually(func() error { return c.Get(context.TODO(), key, instance) }, timeout).Should(Succeed())
 
-				instance.Spec.Reference = "does-not-exist"
+				instance.Spec.Reference = doesNotExistPath
 				err := c.Update(context.TODO(), instance)
 				Expect(err).ToNot(HaveOccurred())
 				// Wait for reconcile for update
@@ -742,7 +744,7 @@ var _ = Describe("GitTrack Suite", func() {
 
 			It("updates the FilesFetched condition", func() {
 				Eventually(func() error { return c.Get(context.TODO(), key, instance) }, timeout).Should(Succeed())
-				instance.Spec.Reference = "does-not-exist"
+				instance.Spec.Reference = doesNotExistPath
 				err := c.Update(context.TODO(), instance)
 				Expect(err).ToNot(HaveOccurred())
 				// Wait for reconcile for update
@@ -772,7 +774,7 @@ var _ = Describe("GitTrack Suite", func() {
 
 			It("sends a CheckoutFailed event", func() {
 				Eventually(func() error { return c.Get(context.TODO(), key, instance) }, timeout).Should(Succeed())
-				instance.Spec.Reference = "does-not-exist"
+				instance.Spec.Reference = doesNotExistPath
 				err := c.Update(context.TODO(), instance)
 				Expect(err).ToNot(HaveOccurred())
 				// Wait for reconcile for update
@@ -821,7 +823,7 @@ var _ = Describe("GitTrack Suite", func() {
 				}, timeout).Should(Succeed())
 				Eventually(func() error { return c.Get(context.TODO(), key, instance) }, timeout).Should(Succeed())
 
-				instance.Spec.SubPath = "does-not-exist"
+				instance.Spec.SubPath = doesNotExistPath
 				err := c.Update(context.TODO(), instance)
 				Expect(err).ToNot(HaveOccurred())
 				// Wait for reconcile for update
@@ -842,7 +844,7 @@ var _ = Describe("GitTrack Suite", func() {
 
 			It("updates the FilesFetched condition", func() {
 				Eventually(func() error { return c.Get(context.TODO(), key, instance) }, timeout).Should(Succeed())
-				instance.Spec.SubPath = "does-not-exist"
+				instance.Spec.SubPath = doesNotExistPath
 				err := c.Update(context.TODO(), instance)
 				Expect(err).ToNot(HaveOccurred())
 				// Wait for reconcile for update
@@ -872,7 +874,7 @@ var _ = Describe("GitTrack Suite", func() {
 
 			It("sends a CheckoutFailed event", func() {
 				Eventually(func() error { return c.Get(context.TODO(), key, instance) }, timeout).Should(Succeed())
-				instance.Spec.SubPath = "does-not-exist"
+				instance.Spec.SubPath = doesNotExistPath
 				err := c.Update(context.TODO(), instance)
 				Expect(err).ToNot(HaveOccurred())
 				// Wait for reconcile for update

--- a/pkg/controller/gittrack/status.go
+++ b/pkg/controller/gittrack/status.go
@@ -24,7 +24,7 @@ import (
 
 	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
 	gittrackutils "github.com/pusher/faros/pkg/controller/gittrack/utils"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 type statusOpts struct {

--- a/pkg/controller/gittrack/utils/conditions.go
+++ b/pkg/controller/gittrack/utils/conditions.go
@@ -18,7 +18,7 @@ package utils
 
 import (
 	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/controller/gittrackobject/gittrackobject_controller_suite_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_suite_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pusher/faros/pkg/apis"
 	farosflags "github.com/pusher/faros/pkg/flags"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/pkg/controller/gittrackobject/status.go
+++ b/pkg/controller/gittrackobject/status.go
@@ -24,7 +24,7 @@ import (
 
 	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
 	gittrackobjectutils "github.com/pusher/faros/pkg/controller/gittrackobject/utils"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 type statusOpts struct {

--- a/pkg/controller/gittrackobject/utils/conditions.go
+++ b/pkg/controller/gittrackobject/utils/conditions.go
@@ -18,7 +18,7 @@ package utils
 
 import (
 	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/test/events/collection.go
+++ b/test/events/collection.go
@@ -16,9 +16,7 @@ limitations under the License.
 
 package events
 
-import (
-	"k8s.io/api/core/v1"
-)
+import v1 "k8s.io/api/core/v1"
 
 // Any returns true if any call to `f` evaluates to `true`
 func Any(events []v1.Event, f func(v1.Event) bool) bool {

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,5 +1,5 @@
 box:
-  id: golang:1.10
+  id: golang:1.11
 
 dep-install:
   steps:

--- a/wercker.yml
+++ b/wercker.yml
@@ -40,26 +40,28 @@ lint:
   - wercker/setup-go-workspace:
       package-dir: github.com/pusher/faros
   - script:
-      name: Install gometalinter
+      name: Install linter
       code: |
-        go get -u github.com/alecthomas/gometalinter
-        gometalinter --install
+        export BIN_DIR=/usr/local/bin
+        export CI_LINT_VERSION=1.15.0
+        export CI_LINT_URI=https://github.com/golangci/golangci-lint/releases/download/v$CI_LINT_VERSION/golangci-lint-$CI_LINT_VERSION-linux-amd64.tar.gz
+        curl -L $CI_LINT_URI | tar -C $BIN_DIR -xzf - --strip-components 1 --wildcards \*/golangci-lint
   - script:
-      name: Run gometalinter
+      name: Run linter(s)
       code: |
-       gometalinter --vendor --disable-all \
-       --enable=vet \
-       --enable=vetshadow \
-       --enable=golint \
-       --enable=ineffassign \
-       --enable=goconst \
-       --enable=deadcode \
-       --enable=gofmt \
-       --enable=goimports \
-       --deadline=60s \
-       --tests ./... \
-       -s pkg/client
-
+        golangci-lint run --disable-all \
+          --enable=vet \
+          --enable=vetshadow \
+          --enable=golint \
+          --enable=ineffassign \
+          --enable=goconst \
+          --enable=deadcode \
+          --enable=gofmt \
+          --enable=goimports \
+          --skip-dirs=pkg/client/ \
+          --deadline=60s \
+          --verbose \
+          --tests ./...
 
 test:
   steps:

--- a/wercker.yml
+++ b/wercker.yml
@@ -59,7 +59,7 @@ lint:
           --enable=gofmt \
           --enable=goimports \
           --skip-dirs=pkg/client/ \
-          --deadline=60s \
+          --deadline=120s \
           --verbose \
           --tests ./...
 


### PR DESCRIPTION
`gometalinter` is deprecated and will be archived in April (https://github.com/alecthomas/gometalinter/issues/590), so we should switch to `golangci-lint`.

I've enabled the same linters as we had with `gometalinter`, and had to fix some files that aren't  "`goimports`-ed (goimports)".