### PR TITLE
Add Server dry run to optimise updates of GTO child resources

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -684,12 +684,12 @@
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:3dd8431d7cb4dd5badfbdf6a9c14fd670a4956c9a17f34e6ec98a59e82fb8de5"
+  digest = "1:40e527269f1feb16b3069bfe80ff05a462d190eacfe07eb0a59fa25c381db7af"
   name = "github.com/russross/blackfriday"
   packages = ["."]
   pruneopts = "T"
-  revision = "d3b5b032dc8e8927d31a5071b56e14c89f045135"
-  version = "v2.0.1"
+  revision = "05f3235734ad95d0016f6a23902f06461fcf567a"
+  version = "v1.5.2"
 
 [[projects]]
   digest = "1:c85dd9a95433394aa8ec4949b5de91398c3e3895db5a341fa27f9e7b251a8cb9"
@@ -697,14 +697,6 @@
   packages = ["diffmatchpatch"]
   pruneopts = "T"
   revision = "1744e2970ca51c86172c8190fadad617561ed6e7"
-  version = "v1.0.0"
-
-[[projects]]
-  digest = "1:9421f6e9e28ef86933e824b5caff441366f2b69bb281085b9dca40e1f27a1602"
-  name = "github.com/shurcooL/sanitized_anchor_name"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "7bfe4c7ecddb3666a94b053b422cdd8f5aaa3615"
   version = "v1.0.0"
 
 [[projects]]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,17 @@
   version = "v0.2.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:6da51e5ec493ad2b44cb04129e2d0a068c8fb9bd6cb5739d199573558696bb94"
+  name = "github.com/Azure/go-ansiterm"
+  packages = [
+    ".",
+    "winterm",
+  ]
+  pruneopts = "T"
+  revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
+
+[[projects]]
   digest = "1:93705be74344cb286cc34bb5697f6b211c2b49baa5f65dd79cd318d5dcc37033"
   name = "github.com/Azure/go-autorest"
   packages = [
@@ -31,6 +42,14 @@
   pruneopts = "T"
   revision = "71d02b67e17a3d80abf8db171f1ca80c39eb2e90"
   version = "v11.4.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:414b0f57170d23e2941aa5cd393e99d0ab7a639e27d9784ef3949eae6cddfdb3"
+  name = "github.com/MakeNowJust/heredoc"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "e9091a26100e9cfb2b6a8f470085bfa541931a91"
 
 [[projects]]
   digest = "1:352fc094dbd1438593b64251de6788bffdf30f9925cf763c7f62e1fd27142b76"
@@ -47,6 +66,14 @@
   packages = ["."]
   pruneopts = "T"
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
+
+[[projects]]
+  digest = "1:e878dfe6e3fb9f3dcd1df02a2fb20ec0cfa2cefb5dc3f09746099a14b91e9774"
+  name = "github.com/Sirupsen/logrus"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:464aef731a5f82ded547c62e249a2e9ec59fbbc9ddab53cda7b9857852630a61"
@@ -94,6 +121,28 @@
   version = "v3.2.0"
 
 [[projects]]
+  digest = "1:737600611200b7066942318948256cde82f62c2cafa0045c483f1c7c5fc0ad2b"
+  name = "github.com/docker/docker"
+  packages = [
+    "pkg/term",
+    "pkg/term/windows",
+  ]
+  pruneopts = "T"
+  revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
+  version = "v1.13.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:0d4540d92fd82f9957e1f718e2b1e5f2d301ed8169e2923bba23558fbbbd08a1"
+  name = "github.com/docker/spdystream"
+  packages = [
+    ".",
+    "spdy",
+  ]
+  pruneopts = "T"
+  revision = "6480d4af844c189cf5dd913db24ddd339d3a4f85"
+
+[[projects]]
   digest = "1:0ffd93121f3971aea43f6a26b3eaaa64c8af20fb0ff0731087d8dab7164af5a8"
   name = "github.com/emicklei/go-restful"
   packages = [
@@ -126,6 +175,14 @@
   pruneopts = "T"
   revision = "afac545df32f2287a079e2dfb7ba2745a643747e"
   version = "v3.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5e0da1aba1a7b125f46e6ddca43e98b40cf6eaea3322b016c331cf6afe53c30a"
+  name = "github.com/exponent-io/jsonpath"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "d6023ce2651d8eafb5c75bb0c7167536102ec9f5"
 
 [[projects]]
   digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
@@ -391,6 +448,14 @@
   version = "0.4"
 
 [[projects]]
+  digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
+  version = "v1.0.2"
+
+[[projects]]
   branch = "controller-platform"
   digest = "1:b3d1d9f131d1e368af28b268782da9885bd963b2f13d15496ca4b7531b0259bd"
   name = "github.com/kubernetes-sigs/kubebuilder"
@@ -450,6 +515,14 @@
   packages = ["."]
   pruneopts = "T"
   revision = "58046073cbffe2f25d425fe1331102f55cf719de"
+
+[[projects]]
+  digest = "1:abf08734a6527df70ed361d7c369fb580e6840d8f7a6012e5f609fdfd93b4e48"
+  name = "github.com/mitchellh/go-wordwrap"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "9e67c67572bc5dd02aef930e2b0ae3c02a4b5a5c"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
@@ -611,11 +684,27 @@
   version = "v0.5.0"
 
 [[projects]]
+  digest = "1:3dd8431d7cb4dd5badfbdf6a9c14fd670a4956c9a17f34e6ec98a59e82fb8de5"
+  name = "github.com/russross/blackfriday"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "d3b5b032dc8e8927d31a5071b56e14c89f045135"
+  version = "v2.0.1"
+
+[[projects]]
   digest = "1:c85dd9a95433394aa8ec4949b5de91398c3e3895db5a341fa27f9e7b251a8cb9"
   name = "github.com/sergi/go-diff"
   packages = ["diffmatchpatch"]
   pruneopts = "T"
   revision = "1744e2970ca51c86172c8190fadad617561ed6e7"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:9421f6e9e28ef86933e824b5caff441366f2b69bb281085b9dca40e1f27a1602"
+  name = "github.com/shurcooL/sanitized_anchor_name"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "7bfe4c7ecddb3666a94b053b422cdd8f5aaa3615"
   version = "v1.0.0"
 
 [[projects]]
@@ -1136,12 +1225,15 @@
     "pkg/util/diff",
     "pkg/util/errors",
     "pkg/util/framer",
+    "pkg/util/httpstream",
+    "pkg/util/httpstream/spdy",
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/jsonmergepatch",
     "pkg/util/mergepatch",
     "pkg/util/naming",
     "pkg/util/net",
+    "pkg/util/remotecommand",
     "pkg/util/runtime",
     "pkg/util/sets",
     "pkg/util/strategicpatch",
@@ -1153,6 +1245,7 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
+    "third_party/forked/golang/netutil",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "T"
@@ -1164,6 +1257,8 @@
   digest = "1:d452565d61cae6f066b9cacff7657d6514adfb1214e008afe9b68300434eae35"
   name = "k8s.io/cli-runtime"
   packages = [
+    "pkg/genericclioptions",
+    "pkg/genericclioptions/printers",
     "pkg/genericclioptions/resource",
     "pkg/kustomize/k8sdeps",
     "pkg/kustomize/k8sdeps/configmapandsecret",
@@ -1304,6 +1399,14 @@
     "rest",
     "rest/watch",
     "restmapper",
+    "scale",
+    "scale/scheme",
+    "scale/scheme/appsint",
+    "scale/scheme/appsv1beta1",
+    "scale/scheme/appsv1beta2",
+    "scale/scheme/autoscalingv1",
+    "scale/scheme/extensionsint",
+    "scale/scheme/extensionsv1beta1",
     "testing",
     "third_party/forked/golang/template",
     "tools/auth",
@@ -1318,10 +1421,13 @@
     "tools/pager",
     "tools/record",
     "tools/reference",
+    "tools/remotecommand",
     "transport",
+    "transport/spdy",
     "util/buffer",
     "util/cert",
     "util/connrotation",
+    "util/exec",
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
@@ -1388,6 +1494,7 @@
   packages = [
     "pkg/common",
     "pkg/util/proto",
+    "pkg/util/proto/validation",
   ]
   pruneopts = "T"
   revision = "f08db293d3ef80052d6513ece19792642a289fea"
@@ -1396,12 +1503,27 @@
   digest = "1:01562a7e9fa8674285e819288aa73217679f3c3f9353aa7c0a21dc1f7919928b"
   name = "k8s.io/kubernetes"
   packages = [
+    "pkg/kubectl/cmd/util",
     "pkg/kubectl/cmd/util/openapi",
+    "pkg/kubectl/cmd/util/openapi/validation",
     "pkg/kubectl/scheme",
+    "pkg/kubectl/util/templates",
+    "pkg/kubectl/util/term",
+    "pkg/kubectl/validation",
+    "pkg/util/interrupt",
+    "pkg/version",
   ]
   pruneopts = "T"
   revision = "eec55b9ba98609a46fee712359c7b5b365bdd920"
   version = "v1.13.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c891eb9bb736124a30371e8c6d0f045c95e5971f93f1a64d4fd8ee4cf98dcadb"
+  name = "k8s.io/utils"
+  packages = ["exec"]
+  pruneopts = "T"
+  revision = "c2654d5206da6b7b6ace12841e8f359bb89b443c"
 
 [[projects]]
   digest = "1:5aa50779f75cc439edd3455a6dee7cf179b52f8dde764a47cc929693485d1afb"
@@ -1572,6 +1694,7 @@
     "k8s.io/client-go/util/workqueue",
     "k8s.io/code-generator/cmd/deepcopy-gen",
     "k8s.io/kube-openapi/pkg/util/proto",
+    "k8s.io/kubernetes/pkg/kubectl/cmd/util",
     "k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi",
     "k8s.io/kubernetes/pkg/kubectl/scheme",
     "sigs.k8s.io/controller-runtime/pkg/cache",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -136,6 +136,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:6c280b44782900265b0827ceb9a7f9982dd15f183f05107b73cc06c65c8dc5b6"
+  name = "github.com/go-logr/glogr"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "03aa3c3200582c33f271f63ba3ae7d23abb9e699"
+  version = "v0.1.0"
+
+[[projects]]
   branch = "master"
   digest = "1:65587005c6fa4293c0b8a2e457e689df7fda48cc5e1f5449ea2c1e7784551558"
   name = "github.com/go-logr/logr"
@@ -1513,11 +1521,13 @@
   analyzer-version = 1
   input-imports = [
     "github.com/emicklei/go-restful",
+    "github.com/go-logr/glogr",
     "github.com/jonboulle/clockwork",
     "github.com/kubernetes-sigs/kubebuilder",
     "github.com/kubernetes-sigs/kubebuilder/pkg/test",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
+    "github.com/onsi/gomega/types",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_model/go",
     "github.com/pusher/git-store",
@@ -1528,6 +1538,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+    "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/meta/testrestmapper",
@@ -1576,6 +1587,7 @@
     "sigs.k8s.io/controller-runtime/pkg/metrics",
     "sigs.k8s.io/controller-runtime/pkg/reconcile",
     "sigs.k8s.io/controller-runtime/pkg/runtime/inject",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/log",
     "sigs.k8s.io/controller-runtime/pkg/runtime/scheme",
     "sigs.k8s.io/controller-runtime/pkg/runtime/signals",
     "sigs.k8s.io/controller-runtime/pkg/source",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -73,3 +73,7 @@ version="v0.1.1"
 name = "gopkg.in/fsnotify.v1"
 source = "https://github.com/fsnotify/fsnotify.git"
 version="v1.4.7"
+
+[[override]]
+name="github.com/russross/blackfriday"
+version="^v1.5.2"

--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -67,16 +67,22 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		panic(fmt.Errorf("unable to create applier: %v", err))
 	}
 
+	dryRunVerifier, err := utils.NewDryRunVerifier(mgr.GetConfig())
+	if err != nil {
+		panic(fmt.Errorf("unable to create dry run verifier: %v", err))
+	}
+
 	return &ReconcileGitTrackObject{
-		Client:      mgr.GetClient(),
-		scheme:      mgr.GetScheme(),
-		eventStream: make(chan event.GenericEvent),
-		cache:       mgr.GetCache(),
-		informers:   make(map[string]toolscache.SharedIndexInformer),
-		config:      mgr.GetConfig(),
-		stop:        stop,
-		recorder:    mgr.GetRecorder("gittrackobject-controller"),
-		applier:     applier,
+		Client:         mgr.GetClient(),
+		scheme:         mgr.GetScheme(),
+		eventStream:    make(chan event.GenericEvent),
+		cache:          mgr.GetCache(),
+		informers:      make(map[string]toolscache.SharedIndexInformer),
+		config:         mgr.GetConfig(),
+		stop:           stop,
+		recorder:       mgr.GetRecorder("gittrackobject-controller"),
+		applier:        applier,
+		dryRunVerifier: dryRunVerifier,
 	}
 }
 
@@ -162,7 +168,8 @@ type ReconcileGitTrackObject struct {
 	stop        chan struct{}
 	recorder    record.EventRecorder
 
-	applier farosclient.Client
+	applier        farosclient.Client
+	dryRunVerifier *utils.DryRunVerifier
 }
 
 // EventStream returns a stream of generic event to trigger reconciles

--- a/pkg/utils/client/apply.go
+++ b/pkg/utils/client/apply.go
@@ -118,6 +118,7 @@ type ApplyOptions struct {
 	CascadeDeletion     *bool
 	DeletionTimeout     *time.Duration
 	DeletionGracePeriod *int
+	ServerDryRun        *bool
 }
 
 // Complete defaults valus within the ApplyOptions struct
@@ -128,6 +129,7 @@ func (a *ApplyOptions) Complete() {
 	cascadeDeletion := true
 	deletionTimeout := time.Duration(30 * time.Second)
 	deletionGracePeriod := -1
+	serverDryRun := false
 
 	if a.Overwrite == nil {
 		a.Overwrite = &overwrite
@@ -143,6 +145,9 @@ func (a *ApplyOptions) Complete() {
 	}
 	if a.DeletionGracePeriod == nil {
 		a.DeletionGracePeriod = &deletionGracePeriod
+	}
+	if a.ServerDryRun == nil {
+		a.ServerDryRun = &serverDryRun
 	}
 }
 

--- a/pkg/utils/client/apply.go
+++ b/pkg/utils/client/apply.go
@@ -197,7 +197,7 @@ func (a *Applier) create(ctx context.Context, opts *ApplyOptions, obj runtime.Ob
 
 	mapping, err := a.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
-		return fmt.Errorf("unable to get rest mapping for GroupVersionKind %s: %v", gvk.String(), err)
+		return fmt.Errorf("unable to get REST mapping for GroupVersionKind %s: %v", gvk.String(), err)
 	}
 
 	metadata, err := meta.Accessor(obj)
@@ -322,7 +322,7 @@ func newUnstructuredFor(obj runtime.Object) *unstructured.Unstructured {
 func (a *Applier) restClientFor(gv schema.GroupVersion) (*rest.RESTClient, error) {
 	restConfig, err := a.configFor(gv)
 	if err != nil {
-		return nil, fmt.Errorf("error constructing config for Group Version %+v: %v", gv, err)
+		return nil, fmt.Errorf("failed to construct config for Group Version %+v: %v", gv, err)
 	}
 	restClient, err := rest.RESTClientFor(restConfig)
 	if err != nil {

--- a/pkg/utils/client/apply.go
+++ b/pkg/utils/client/apply.go
@@ -22,12 +22,14 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/jonboulle/clockwork"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -168,7 +170,7 @@ func (a *Applier) Apply(ctx context.Context, opts *ApplyOptions, modified runtim
 	err = a.client.Get(context.TODO(), objectKey, current)
 	if err != nil && errors.IsNotFound(err) {
 		// Object is not found, create it
-		return a.create(ctx, modified.DeepCopyObject())
+		return a.create(ctx, opts, modified)
 	} else if err != nil {
 		return fmt.Errorf("unable to get current resource: %v", err)
 	}
@@ -178,17 +180,44 @@ func (a *Applier) Apply(ctx context.Context, opts *ApplyOptions, modified runtim
 		return fmt.Errorf("error applying update: %v", err)
 	}
 
-	// Fetch the updated resource so that users copy is up to date
-	return a.client.Get(context.TODO(), objectKey, modified)
+	return nil
 }
 
-func (a *Applier) create(ctx context.Context, obj runtime.Object) error {
+func (a *Applier) create(ctx context.Context, opts *ApplyOptions, obj runtime.Object) error {
 	err := createApplyAnnotation(obj, unstructured.UnstructuredJSONScheme)
 	if err != nil {
 		return fmt.Errorf("unable to apply LastAppliedAnnotation to object: %v", err)
 	}
 
-	err = a.client.Create(ctx, obj)
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	restClient, err := a.restClientFor(gvk.GroupVersion())
+	if err != nil {
+		return fmt.Errorf("unable to construct REST client for GroupVersion %s: %v", gvk.GroupVersion().String(), err)
+	}
+
+	mapping, err := a.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return fmt.Errorf("unable to get rest mapping for GroupVersionKind %s: %v", gvk.String(), err)
+	}
+
+	metadata, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("unable to get metadata: %v", err)
+	}
+
+	createOptions := &metav1.CreateOptions{}
+	if *opts.ServerDryRun {
+		createOptions.DryRun = []string{metav1.DryRunAll}
+	}
+
+	err = restClient.Post().
+		NamespaceIfScoped(metadata.GetNamespace(), isNamespaced(mapping)).
+		Resource(mapping.Resource.Resource).
+		Body(obj).
+		VersionedParams(createOptions, metav1.ParameterCodec).
+		Context(ctx).
+		Do().
+		Into(obj)
 	if err != nil {
 		return fmt.Errorf("error creating object: %v", err)
 	}
@@ -211,11 +240,16 @@ func (a *Applier) update(ctx context.Context, opts *ApplyOptions, current, modif
 		return fmt.Errorf("unable to construct patcher: %v", err)
 	}
 	source := metadata.GetSelfLink() // This is optional and would normally be the file path
-	_, _, err = patcher.Patch(current, modifiedJSON, source, metadata.GetNamespace(), metadata.GetName(), nil)
+	_, patchedObj, err := patcher.Patch(current, modifiedJSON, source, metadata.GetNamespace(), metadata.GetName(), nil)
 	if err != nil {
 		return fmt.Errorf("unable to patch object: %v", err)
 	}
 
+	// Copy the patchedObj into the modified runtime.Object
+	err = a.copyInto(patchedObj, modified)
+	if err != nil {
+		return fmt.Errorf("error copying response: %v", err)
+	}
 	return nil
 }
 
@@ -226,13 +260,9 @@ func (a *Applier) newPatcher(opts *ApplyOptions, obj runtime.Object) (*Patcher, 
 		return nil, fmt.Errorf("couldn't construct rest mapping from GVK %s: %v", gvk.String(), err)
 	}
 
-	restConfig, err := a.configFor(gvk.GroupVersion())
+	restClient, err := a.restClientFor(gvk.GroupVersion())
 	if err != nil {
-		return nil, fmt.Errorf("error constructing config for Group Version %+v: %v", gvk.GroupVersion(), err)
-	}
-	restClient, err := rest.RESTClientFor(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialise rest client: %v", err)
+		return nil, fmt.Errorf("unable to get REST Client: %v", err)
 	}
 
 	helper := resource.NewHelper(restClient, mapping)
@@ -246,8 +276,8 @@ func (a *Applier) newPatcher(opts *ApplyOptions, obj runtime.Object) (*Patcher, 
 		Cascade:       *opts.CascadeDeletion,
 		Timeout:       *opts.DeletionTimeout,
 		GracePeriod:   *opts.DeletionGracePeriod,
-		ServerDryRun:  false, // TODO(JoelSpeed): Implement ServerDryRun in Apply
-		OpenapiSchema: nil,   // Not supporting OpenapiSchema patching
+		ServerDryRun:  *opts.ServerDryRun,
+		OpenapiSchema: nil, // Not supporting OpenapiSchema patching
 		Retries:       maxPatchRetry,
 	}
 	return p, nil
@@ -287,4 +317,36 @@ func newUnstructuredFor(obj runtime.Object) *unstructured.Unstructured {
 	u.SetAPIVersion(apiVersion)
 
 	return u
+}
+
+func (a *Applier) restClientFor(gv schema.GroupVersion) (*rest.RESTClient, error) {
+	restConfig, err := a.configFor(gv)
+	if err != nil {
+		return nil, fmt.Errorf("error constructing config for Group Version %+v: %v", gv, err)
+	}
+	restClient, err := rest.RESTClientFor(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialise rest client: %v", err)
+	}
+	return restClient, nil
+}
+
+func (a *Applier) copyInto(in, out runtime.Object) error {
+	data, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+	gvk := in.GetObjectKind().GroupVersionKind()
+	_, _, err = a.codecs.UniversalDecoder().Decode(data, &gvk, out)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func isNamespaced(mapping *meta.RESTMapping) bool {
+	if mapping.Scope.Name() == meta.RESTScopeNameRoot {
+		return false
+	}
+	return true
 }

--- a/pkg/utils/client/apply_test.go
+++ b/pkg/utils/client/apply_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pusher/faros/pkg/utils/client/test"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var _ = Describe("Applier Suite", func() {
+	var c client.Client
+	var a Client
+	var o *ApplyOptions
+	var m test.Matcher
+
+	var deployment *appsv1.Deployment
+	var mgrStopped *sync.WaitGroup
+	var stopMgr chan struct{}
+
+	const timeout = time.Second * 5
+	const consistentlyTimeout = time.Second
+
+	BeforeEach(func() {
+		mgr, err := manager.New(cfg, manager.Options{})
+		Expect(err).NotTo(HaveOccurred())
+		c = mgr.GetClient()
+		m = test.Matcher{Client: c}
+
+		a, err = NewApplier(mgr.GetConfig(), Options{})
+		Expect(err).NotTo(HaveOccurred())
+		o = &ApplyOptions{}
+
+		stopMgr, mgrStopped = StartTestManager(mgr)
+
+		deployment = test.ExampleDeployment.DeepCopy()
+	})
+
+	AfterEach(func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+
+		test.DeleteAll(cfg, timeout,
+			&appsv1.DeploymentList{},
+		)
+	})
+
+	Describe("when the deployment does not exist", func() {
+		BeforeEach(func() {
+			a.Apply(context.TODO(), o, deployment)
+		})
+
+		It("creates the deployment", func() {
+			m.Get(deployment, timeout).Should(Succeed())
+		})
+	})
+})

--- a/pkg/utils/client/apply_test.go
+++ b/pkg/utils/client/apply_test.go
@@ -41,7 +41,6 @@ var _ = Describe("Applier Suite", func() {
 	var stopMgr chan struct{}
 
 	const timeout = time.Second * 5
-	const consistentlyTimeout = time.Second
 
 	BeforeEach(func() {
 		mgr, err := manager.New(cfg, manager.Options{})

--- a/pkg/utils/client/client_suite_test.go
+++ b/pkg/utils/client/client_suite_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"log"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/glogr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var cfg *rest.Config
+
+func TestMain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Client Controller Suite")
+}
+
+var t *envtest.Environment
+
+var _ = BeforeSuite(func() {
+	t = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+	}
+
+	logf.SetLogger(glogr.New())
+
+	var err error
+	if cfg, err = t.Start(); err != nil {
+		log.Fatal(err)
+	}
+})
+
+var _ = AfterSuite(func() {
+	t.Stop()
+})
+
+// SetupTestReconcile returns a reconcile.Reconcile implementation that delegates to inner and
+// writes the request to requests after Reconcile is finished.
+func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan reconcile.Request) {
+	requests := make(chan reconcile.Request)
+	fn := reconcile.Func(func(req reconcile.Request) (reconcile.Result, error) {
+		result, err := inner.Reconcile(req)
+		requests <- req
+		return result, err
+	})
+	return fn, requests
+}
+
+// StartTestManager adds recFn
+func StartTestManager(mgr manager.Manager) (chan struct{}, *sync.WaitGroup) {
+	stop := make(chan struct{})
+	wg := &sync.WaitGroup{}
+	go func() {
+		defer GinkgoRecover()
+		wg.Add(1)
+		Expect(mgr.Start(stop)).NotTo(HaveOccurred())
+		wg.Done()
+	}()
+	return stop, wg
+}

--- a/pkg/utils/client/client_suite_test.go
+++ b/pkg/utils/client/client_suite_test.go
@@ -74,11 +74,11 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 func StartTestManager(mgr manager.Manager) (chan struct{}, *sync.WaitGroup) {
 	stop := make(chan struct{})
 	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		defer GinkgoRecover()
-		wg.Add(1)
 		Expect(mgr.Start(stop)).NotTo(HaveOccurred())
-		wg.Done()
 	}()
 	return stop, wg
 }

--- a/pkg/utils/client/client_suite_test.go
+++ b/pkg/utils/client/client_suite_test.go
@@ -36,7 +36,7 @@ var cfg *rest.Config
 
 func TestMain(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Client Controller Suite")
+	RunSpecs(t, "Client Suite")
 }
 
 var t *envtest.Environment

--- a/pkg/utils/client/test/delete.go
+++ b/pkg/utils/client/test/delete.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"time"
+
+	g "github.com/onsi/gomega"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DeleteAll lists and deletes all resources
+func DeleteAll(cfg *rest.Config, timeout time.Duration, objLists ...runtime.Object) {
+	c, err := client.New(rest.CopyConfig(cfg), client.Options{})
+	g.Expect(err).ToNot(g.HaveOccurred())
+	for _, objList := range objLists {
+		g.Eventually(func() error {
+			return c.List(context.TODO(), &client.ListOptions{}, objList)
+		}, timeout).Should(g.Succeed())
+		objs, err := apimeta.ExtractList(objList)
+		g.Expect(err).ToNot(g.HaveOccurred())
+		errs := make(chan error, len(objs))
+		for _, obj := range objs {
+			go func(o runtime.Object) {
+				errs <- c.Delete(context.TODO(), o)
+			}(obj)
+		}
+		for range objs {
+			g.Expect(<-errs).ToNot(g.HaveOccurred())
+		}
+	}
+}

--- a/pkg/utils/client/test/matchers.go
+++ b/pkg/utils/client/test/matchers.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+
+	"github.com/onsi/gomega"
+	gtypes "github.com/onsi/gomega/types"
+	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// Matcher has Gomega Matchers that use the controller-runtime client
+type Matcher struct {
+	Client client.Client
+}
+
+// Object is the combination of two interfaces as a helper for passing
+// Kubernetes objects between methods
+type Object interface {
+	runtime.Object
+	metav1.Object
+}
+
+// Create creates the object on the API server
+func (m *Matcher) Create(obj Object, extras ...interface{}) gomega.GomegaAssertion {
+	err := m.Client.Create(context.TODO(), obj)
+	return gomega.Expect(err, extras)
+}
+
+// Delete deletes the object from the API server
+func (m *Matcher) Delete(obj Object, extras ...interface{}) gomega.GomegaAssertion {
+	err := m.Client.Delete(context.TODO(), obj)
+	return gomega.Expect(err, extras)
+}
+
+// Update udpates the object on the API server
+func (m *Matcher) Update(obj Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+	update := func() error {
+		return m.Client.Update(context.TODO(), obj)
+	}
+	return gomega.Eventually(update, intervals...)
+}
+
+// Get gets the object from the API server
+func (m *Matcher) Get(obj Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+	key := types.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+	get := func() error {
+		return m.Client.Get(context.TODO(), key, obj)
+	}
+	return gomega.Eventually(get, intervals...)
+}
+
+// Consistently continually gets the object from the API for comparison
+func (m *Matcher) Consistently(obj Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+	return m.consistentlyObject(obj, intervals...)
+}
+
+// consistentlyObject gets an individual object from the API server
+func (m *Matcher) consistentlyObject(obj Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+	key := types.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+	get := func() Object {
+		err := m.Client.Get(context.TODO(), key, obj)
+		if err != nil {
+			panic(err)
+		}
+		return obj
+	}
+	return gomega.Consistently(get, intervals...)
+}
+
+// Eventually continually gets the object from the API for comparison
+func (m *Matcher) Eventually(obj runtime.Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+	// If the object is a list, return a list
+	if meta.IsListType(obj) {
+		return m.eventuallyList(obj, intervals...)
+	}
+	if o, ok := obj.(Object); ok {
+		return m.eventuallyObject(o, intervals...)
+	}
+	//Should not get here
+	panic("Unknown object.")
+}
+
+// eventuallyObject gets an individual object from the API server
+func (m *Matcher) eventuallyObject(obj Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+	key := types.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+	get := func() Object {
+		err := m.Client.Get(context.TODO(), key, obj)
+		if err != nil {
+			panic(err)
+		}
+		return obj
+	}
+	return gomega.Eventually(get, intervals...)
+}
+
+// eventuallyList gets a list type  from the API server
+func (m *Matcher) eventuallyList(obj runtime.Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+	list := func() runtime.Object {
+		err := m.Client.List(context.TODO(), &client.ListOptions{}, obj)
+		if err != nil {
+			panic(err)
+		}
+		return obj
+	}
+	return gomega.Eventually(list, intervals...)
+}
+
+// WithAnnotations returns the object's Annotations
+func WithAnnotations(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj Object) map[string]string {
+		return obj.GetAnnotations()
+	}, matcher)
+}
+
+// WithPodTemplateAnnotations returns the object's Annotations
+func WithPodTemplateAnnotations(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj *appsv1.Deployment) map[string]string {
+		return obj.Spec.Template.GetAnnotations()
+	}, matcher)
+}
+
+// WithPodTemplateLabels returns the object's Labels
+func WithPodTemplateLabels(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj *appsv1.Deployment) map[string]string {
+		return obj.Spec.Template.GetLabels()
+	}, matcher)
+}
+
+// WithFinalizers returns the object's Annotations
+func WithFinalizers(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj Object) []string {
+		return obj.GetFinalizers()
+	}, matcher)
+}
+
+// WithOwnerReferences returns the object's OwnerReferences
+func WithOwnerReferences(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj Object) []metav1.OwnerReference {
+		return obj.GetOwnerReferences()
+	}, matcher)
+}
+
+// WithResourceVersion returns the object's ResourceVersion
+func WithResourceVersion(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj Object) string {
+		return obj.GetResourceVersion()
+	}, matcher)
+}
+
+// WithUID returns the object's UID
+func WithUID(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj Object) types.UID {
+		return obj.GetUID()
+	}, matcher)
+}
+
+// WithUnstructuredObject returns the objects inner object
+func WithUnstructuredObject(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(ev event.GenericEvent) unstructured.Unstructured {
+		u, ok := ev.Object.(*unstructured.Unstructured)
+		if !ok {
+			panic("Non unstructured object")
+		}
+		return *u
+	}, matcher)
+}
+
+// WithGitTrackObjectStatusConditions returns the GitTrackObjects status conditions
+func WithGitTrackObjectStatusConditions(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(gto farosv1alpha1.GitTrackObjectInterface) []farosv1alpha1.GitTrackObjectCondition {
+		return gto.GetStatus().Conditions
+	}, matcher)
+}
+
+// WithGitTrackObjectConditionType returns the GitTrackObjectsCondition's type
+func WithGitTrackObjectConditionType(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(c farosv1alpha1.GitTrackObjectCondition) farosv1alpha1.GitTrackObjectConditionType {
+		return c.Type
+	}, matcher)
+}
+
+// WithGitTrackObjectConditionStatus returns the GitTrackObjectsCondition's status
+func WithGitTrackObjectConditionStatus(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(c farosv1alpha1.GitTrackObjectCondition) corev1.ConditionStatus {
+		return c.Status
+	}, matcher)
+}
+
+// WithGitTrackObjectConditionReason returns the GitTrackObjectsCondition's reason
+func WithGitTrackObjectConditionReason(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(c farosv1alpha1.GitTrackObjectCondition) string {
+		return c.Reason
+	}, matcher)
+}
+
+// WithGitTrackObjectConditionMessage returns the GitTrackObjectsCondition's message
+func WithGitTrackObjectConditionMessage(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(c farosv1alpha1.GitTrackObjectCondition) string {
+		return c.Message
+	}, matcher)
+}
+
+// WithItems returns the lists Items
+func WithItems(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj runtime.Object) []runtime.Object {
+		items, err := meta.ExtractList(obj)
+		if err != nil {
+			panic(err)
+		}
+		return items
+	}, matcher)
+}
+
+// WithSubjects returns the ClusterRoleBindings subjects
+func WithSubjects(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(crb *rbacv1.ClusterRoleBinding) []rbacv1.Subject {
+		return crb.Subjects
+	}, matcher)
+}
+
+// WithInvolvedObjectKind returns the event's InvolvedObject's Kind
+func WithInvolvedObjectKind(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(ev *corev1.Event) string {
+		return ev.InvolvedObject.Kind
+	}, matcher)
+}
+
+// WithInvolvedObjectName returns the event's InvolvedObject's Name
+func WithInvolvedObjectName(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(ev *corev1.Event) string {
+		return ev.InvolvedObject.Name
+	}, matcher)
+}
+
+// WithInvolvedObjectNamespace returns the event's InvolvedObject's Namespace
+func WithInvolvedObjectNamespace(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(ev *corev1.Event) string {
+		return ev.InvolvedObject.Namespace
+	}, matcher)
+}
+
+// WithReason returns the event's Reason
+func WithReason(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(ev *corev1.Event) string {
+		return ev.Reason
+	}, matcher)
+}
+
+// WithEventType returns the event's Type
+func WithEventType(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(ev *corev1.Event) string {
+		return ev.Type
+	}, matcher)
+}
+
+// WithContainers returns the deployments Containers
+func WithContainers(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(dep *appsv1.Deployment) []corev1.Container {
+		return dep.Spec.Template.Spec.Containers
+	}, matcher)
+}
+
+// WithImage returns the container's image
+func WithImage(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(c corev1.Container) string {
+		return c.Image
+	}, matcher)
+}

--- a/pkg/utils/client/test/matchers.go
+++ b/pkg/utils/client/test/matchers.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -44,6 +45,7 @@ type Matcher struct {
 type Object interface {
 	runtime.Object
 	metav1.Object
+	schema.ObjectKind
 }
 
 // Create creates the object on the API server
@@ -165,6 +167,22 @@ func WithPodTemplateLabels(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
 func WithFinalizers(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
 	return gomega.WithTransform(func(obj Object) []string {
 		return obj.GetFinalizers()
+	}, matcher)
+}
+
+// WithKind returns the objects TypeMeta
+func WithKind(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj Object) string {
+		_, kind := obj.GroupVersionKind().ToAPIVersionAndKind()
+		return kind
+	}, matcher)
+}
+
+// WithAPIVersion returns the objects TypeMeta
+func WithAPIVersion(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj Object) string {
+		apiVersion, _ := obj.GroupVersionKind().ToAPIVersionAndKind()
+		return apiVersion
 	}, matcher)
 }
 

--- a/pkg/utils/client/test/matchers.go
+++ b/pkg/utils/client/test/matchers.go
@@ -182,6 +182,20 @@ func WithResourceVersion(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
 	}, matcher)
 }
 
+// WithCreationTimestamp returns the object's CreationTimestamp
+func WithCreationTimestamp(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj Object) metav1.Time {
+		return obj.GetCreationTimestamp()
+	}, matcher)
+}
+
+// WithSelfLink returns the object's SelfLink
+func WithSelfLink(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
+	return gomega.WithTransform(func(obj Object) string {
+		return obj.GetSelfLink()
+	}, matcher)
+}
+
 // WithUID returns the object's UID
 func WithUID(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
 	return gomega.WithTransform(func(obj Object) types.UID {

--- a/pkg/utils/client/test/test_objects.go
+++ b/pkg/utils/client/test/test_objects.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var appNginx = map[string]string{
+	"app": "nginx",
+}
+
+// ExampleDeployment is an example Deployment object for use within test suites
+var ExampleDeployment = &appsv1.Deployment{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "example",
+		Namespace: "default",
+		Labels:    appNginx,
+	},
+	Spec: appsv1.DeploymentSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: appNginx,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: appNginx,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "nginx",
+						Image: "nginx",
+					},
+				},
+			},
+		},
+	},
+}
+
+// ExampleClusterRoleBinding is an example ClusterRoleBinding object for use within test suites
+var ExampleClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "ClusterRoleBinding",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:   "example",
+		Labels: appNginx,
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "nginx-ingress-controller",
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "nginx-ingress-controller",
+			Namespace: "example",
+		},
+	},
+}

--- a/pkg/utils/client/test/test_objects.go
+++ b/pkg/utils/client/test/test_objects.go
@@ -19,7 +19,6 @@ package test
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,30 +53,6 @@ var ExampleDeployment = &appsv1.Deployment{
 					},
 				},
 			},
-		},
-	},
-}
-
-// ExampleClusterRoleBinding is an example ClusterRoleBinding object for use within test suites
-var ExampleClusterRoleBinding = &rbacv1.ClusterRoleBinding{
-	TypeMeta: metav1.TypeMeta{
-		APIVersion: "rbac.authorization.k8s.io/v1",
-		Kind:       "ClusterRoleBinding",
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:   "example",
-		Labels: appNginx,
-	},
-	RoleRef: rbacv1.RoleRef{
-		APIGroup: "rbac.authorization.k8s.io",
-		Kind:     "ClusterRole",
-		Name:     "nginx-ingress-controller",
-	},
-	Subjects: []rbacv1.Subject{
-		{
-			Kind:      "ServiceAccount",
-			Name:      "nginx-ingress-controller",
-			Namespace: "example",
 		},
 	},
 }

--- a/pkg/utils/dry_run_verifier.go
+++ b/pkg/utils/dry_run_verifier.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
+)
+
+// DryRunVerifier verifies if a given group-version-kind supports DryRun
+// against the current server. Sending dryRun requests to apiserver that
+// don't support it will result in objects being unwillingly persisted.
+//
+// It reads the OpenAPI to see if the given GVK supports dryRun. If the
+// GVK can not be found, we assume that CRDs will have the same level of
+// support as "namespaces", and non-CRDs will not be supported. We
+// delay the check for CRDs as much as possible though, since it
+// requires an extra round-trip to the server.
+type DryRunVerifier struct {
+	Finder        cmdutil.CRDFinder
+	OpenAPIGetter discovery.OpenAPISchemaInterface
+}
+
+// HasSupport verifies if the given gvk supports DryRun. An error is
+// returned if it doesn't.
+func (v *DryRunVerifier) HasSupport(gvk schema.GroupVersionKind) error {
+	oapi, err := v.OpenAPIGetter.OpenAPISchema()
+	if err != nil {
+		return fmt.Errorf("failed to download openapi: %v", err)
+	}
+	supports, err := openapi.SupportsDryRun(oapi, gvk)
+	if err != nil {
+		// We assume that we couldn't find the type, then check for namespace:
+		supports, _ = openapi.SupportsDryRun(oapi, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"})
+		// If namespace supports dryRun, then we will support dryRun for CRDs only.
+		if supports {
+			supports, err = v.Finder.HasCRD(gvk.GroupKind())
+			if err != nil {
+				return fmt.Errorf("failed to check CRD: %v", err)
+			}
+		}
+	}
+	if !supports {
+		return fmt.Errorf("%v doesn't support dry-run", gvk)
+	}
+	return nil
+}
+
+// NewDryRunVerifier constructs a new DryRunVerifier
+func NewDryRunVerifier(config *rest.Config) (*DryRunVerifier, error) {
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Dynamic Client: %v", err)
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Discovery Client: %v", err)
+	}
+
+	return &DryRunVerifier{
+		Finder:        cmdutil.NewCRDFinder(cmdutil.CRDFromDynamic(dynamicClient)),
+		OpenAPIGetter: discoveryClient,
+	}, nil
+}

--- a/pkg/utils/dry_run_verifier.go
+++ b/pkg/utils/dry_run_verifier.go
@@ -70,12 +70,12 @@ func (v *DryRunVerifier) HasSupport(gvk schema.GroupVersionKind) error {
 func NewDryRunVerifier(config *rest.Config) (*DryRunVerifier, error) {
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Dynamic Client: %v", err)
+		return nil, fmt.Errorf("failed to create Dynamic Client: %v", err)
 	}
 
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Discovery Client: %v", err)
+		return nil, fmt.Errorf("failed to create Discovery Client: %v", err)
 	}
 
 	return &DryRunVerifier{

--- a/wercker.yml
+++ b/wercker.yml
@@ -74,8 +74,8 @@ test:
   - script:
       name: Setup Test environment
       code: |
-        export version=1.0.8 # latest stable version
-        export arch=amd64
+        version=1.0.8 # latest stable version
+        arch=amd64
 
         # download the release
         curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz"

--- a/wercker.yml
+++ b/wercker.yml
@@ -74,16 +74,22 @@ test:
   - script:
       name: Setup Test environment
       code: |
+        export version=1.0.8 # latest stable version
+        export arch=amd64
+
+        # download the release
+        curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz"
+        tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz
+
         export TEST_ASSET_DIR=/usr/local/bin
         export TEST_ASSET_KUBECTL=$TEST_ASSET_DIR/kubectl
         export TEST_ASSET_KUBE_APISERVER=$TEST_ASSET_DIR/kube-apiserver
         export TEST_ASSET_ETCD=$TEST_ASSET_DIR/etcd
 
-        # Download test framework binaries
-        export TEST_ASSET_URL=https://storage.googleapis.com/k8s-c10s-test-binaries
-        curl $TEST_ASSET_URL/etcd-Linux-x86_64 --output $TEST_ASSET_ETCD
-        curl $TEST_ASSET_URL/kube-apiserver-Linux-x86_64 --output $TEST_ASSET_KUBE_APISERVER
-        curl https://storage.googleapis.com/kubernetes-release/release/v1.9.2/bin/linux/amd64/kubectl --output $TEST_ASSET_KUBECTL
+        mv kubebuilder_${version}_linux_${arch}/bin/etcd $TEST_ASSET_ETCD
+        mv kubebuilder_${version}_linux_${arch}/bin/kube-apiserver $TEST_ASSET_KUBE_APISERVER
+        mv kubebuilder_${version}_linux_${arch}/bin/kubectl $TEST_ASSET_KUBECTL
+
         chmod +x $TEST_ASSET_ETCD
         chmod +x $TEST_ASSET_KUBE_APISERVER
         chmod +x $TEST_ASSET_KUBECTL


### PR DESCRIPTION
This adds a ServerDryRun option to the `Applier` and then uses it within the GTO controller to only send updates to child resources when they need it. Falling back to the current behaviour if server side dry run isn't supported.