### PR TITLE
Lazily discover CRD rest mappings

### DIFF
--- a/pkg/utils/client/apply.go
+++ b/pkg/utils/client/apply.go
@@ -85,10 +85,16 @@ func NewApplier(config *rest.Config, options Options) (*Applier, error) {
 	// Init a Mapper if none provided
 	if options.Mapper == nil {
 		var err error
-		options.Mapper, err = apiutil.NewDiscoveryRESTMapper(config)
+
+		drm, err := apiutil.NewDiscoveryRESTMapper(config)
 		if err != nil {
 			return nil, err
 		}
+		lrm := meta.NewLazyRESTMapperLoader(func() (meta.RESTMapper, error) {
+			return apiutil.NewDiscoveryRESTMapper(config)
+		})
+
+		options.Mapper = meta.FirstHitRESTMapper{MultiRESTMapper: meta.MultiRESTMapper{drm, lrm}}
 	}
 
 	cachingClient, err := client.New(config, client.Options{Scheme: options.Scheme, Mapper: options.Mapper})

--- a/pkg/utils/client/apply_test.go
+++ b/pkg/utils/client/apply_test.go
@@ -25,7 +25,11 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pusher/faros/pkg/utils/client/test"
 	appsv1 "k8s.io/api/apps/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -43,7 +47,11 @@ var _ = Describe("Applier Suite", func() {
 	const timeout = time.Second * 5
 
 	BeforeEach(func() {
-		mgr, err := manager.New(cfg, manager.Options{})
+		schm := scheme.Scheme
+		Expect(apiextensionsv1beta1.AddToScheme(schm)).To(Succeed())
+		mgr, err := manager.New(cfg, manager.Options{
+			Scheme: schm,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		c = mgr.GetClient()
 		m = test.Matcher{Client: c}
@@ -63,6 +71,7 @@ var _ = Describe("Applier Suite", func() {
 
 		test.DeleteAll(cfg, timeout,
 			&appsv1.DeploymentList{},
+			&apiextensionsv1beta1.CustomResourceDefinitionList{},
 		)
 	})
 
@@ -185,6 +194,35 @@ var _ = Describe("Applier Suite", func() {
 						Not(ContainElement(test.WithImage(Equal("nginx:latest")))),
 					)))
 				})
+			})
+		})
+	})
+
+	Describe("with CRDs", func() {
+		var foo *unstructured.Unstructured
+		var crd *apiextensionsv1beta1.CustomResourceDefinition
+
+		BeforeEach(func() {
+			foo = test.ExampleFoo.DeepCopy()
+			crd = test.ExampleCRD.DeepCopy()
+		})
+
+		Describe("when the CRD is not installed", func() {
+			It("should return an error when applying the CRD", func() {
+				err := a.Apply(context.TODO(), &ApplyOptions{}, foo)
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).Should(Equal("unable to get current resource: no matches for kind \"Foo\" in version \"example.com/v1\""))
+			})
+		})
+
+		Describe("when the CRD is installed", func() {
+			BeforeEach(func() {
+				m.Create(crd).Should(Succeed())
+				m.Get(crd, timeout).Should(Succeed())
+			})
+
+			It("should not return an error when applying the CRD", func() {
+				Expect(a.Apply(context.TODO(), &ApplyOptions{}, foo)).ToNot(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/utils/client/client_suite_test.go
+++ b/pkg/utils/client/client_suite_test.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"log"
-	"path/filepath"
 	"sync"
 	"testing"
 
@@ -42,9 +41,7 @@ func TestMain(t *testing.T) {
 var t *envtest.Environment
 
 var _ = BeforeSuite(func() {
-	t = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
-	}
+	t = &envtest.Environment{}
 
 	logf.SetLogger(glogr.New())
 

--- a/pkg/utils/client/test/test_objects.go
+++ b/pkg/utils/client/test/test_objects.go
@@ -19,7 +19,9 @@ package test
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var appNginx = map[string]string{
@@ -53,6 +55,41 @@ var ExampleDeployment = &appsv1.Deployment{
 					},
 				},
 			},
+		},
+	},
+}
+
+// ExampleCRD is an example CRD object for use within test suites
+var ExampleCRD = &apiextensionsv1beta1.CustomResourceDefinition{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "apiextensions.k8s.io/v1beta1",
+		Kind:       "CustomResourceDefinition",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "foos.example.com",
+	},
+	Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+		Group: "example.com",
+		Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+			Kind:   "Foo",
+			Plural: "foos",
+		},
+		Scope:   apiextensionsv1beta1.NamespaceScoped,
+		Version: "v1",
+	},
+}
+
+// ExampleFoo is an example Foo object for use within test suites
+var ExampleFoo = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "example.com/v1",
+		"kind":       "Foo",
+		"metadata": map[string]interface{}{
+			"name":      "example",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"foo": "bar",
 		},
 	},
 }


### PR DESCRIPTION
Fixes #80 

This change ensures that custom resources with definitions installed _after_ the controller has started up can be reconciled once the definition has been installed.