### PR TITLE
Check for dry run support before sending updates

### DIFF
--- a/pkg/controller/gittrackobject/handler.go
+++ b/pkg/controller/gittrackobject/handler.go
@@ -210,11 +210,8 @@ func (r *ReconcileGitTrackObject) handleRecreateUpdateStrategy(gto farosv1alpha1
 
 // recreateChild first deletes and then creates a child resource for a (Cluster)GitTrackObject
 func (r *ReconcileGitTrackObject) recreateChild(found, child *unstructured.Unstructured) (bool, error) {
-	// HasSupport returns an error if dry run not supported
-	if err := r.dryRunVerifier.HasSupport(child.GroupVersionKind()); err == nil {
-		return r.applyChildWithDryRun(found, child, true)
-	}
-	// Dry run not supported so apply without DryRun
+	// Recreating the child does not make sense with dry run (dry run delete does
+	// not mean we can dry run create) and so do not attempt dry run here.
 	return r.applyChild(found, child, true)
 }
 

--- a/pkg/controller/gittrackobject/handler.go
+++ b/pkg/controller/gittrackobject/handler.go
@@ -210,15 +210,22 @@ func (r *ReconcileGitTrackObject) handleRecreateUpdateStrategy(gto farosv1alpha1
 
 // recreateChild first deletes and then creates a child resource for a (Cluster)GitTrackObject
 func (r *ReconcileGitTrackObject) recreateChild(found, child *unstructured.Unstructured) (bool, error) {
-	if err := r.dryRunVerifier.HasSupport(child.GroupVersionKind()); err != nil {
+	// HasSupport returns an error if dry run not supported
+	if err := r.dryRunVerifier.HasSupport(child.GroupVersionKind()); err == nil {
 		return r.applyChildWithDryRun(found, child, true)
 	}
+	// Dry run not supported so apply without DryRun
 	return r.applyChild(found, child, true)
 }
 
 // updateChild updates the given child resource of a (Cluster)GitTrackObject
 func (r *ReconcileGitTrackObject) updateChild(found, child *unstructured.Unstructured) (bool, error) {
-	return r.applyChildWithDryRun(found, child, false)
+	// HasSupport returns an error if dry run not supported
+	if err := r.dryRunVerifier.HasSupport(child.GroupVersionKind()); err == nil {
+		return r.applyChildWithDryRun(found, child, false)
+	}
+	// Dry run not supported so apply without DryRun
+	return r.applyChild(found, child, false)
 }
 
 // applyChildWithDryRun first applies the child with DryRun and then updates the resource if there is change to persist


### PR DESCRIPTION
Fixes #95 

This is an attempt to retain backwards compatibility with older versions of Kubernetes.

I found that the pre-check for using dry run was only implemented in one of the two places it should have been (we should really refactor that somehow) and also there was an `err != nil` that should have been `err == nil` 🤦‍♂️ 

@sebastianroesch What do you think of this fix?
