### PR TITLE
Add JUnit reporting capability to test suites

### DIFF
--- a/pkg/apis/faros/v1alpha1/v1alpha1_suite_test.go
+++ b/pkg/apis/faros/v1alpha1/v1alpha1_suite_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	_ "github.com/pusher/faros/test/reporters" // Not using ginkgo here but need the flags set from this package
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/controller/gittrack/gittrack_controller_suite_test.go
+++ b/pkg/controller/gittrack/gittrack_controller_suite_test.go
@@ -25,11 +25,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kubernetes-sigs/kubebuilder/pkg/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pusher/faros/pkg/apis"
 	farosflags "github.com/pusher/faros/pkg/flags"
+	"github.com/pusher/faros/test/reporters"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -63,7 +63,7 @@ func teardownRepository(dir string) {
 
 func TestBee(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "GitTrack Suite", []Reporter{test.NewlineReporter{}})
+	RunSpecsWithDefaultAndCustomReporters(t, "GitTrack Suite", reporters.Reporters())
 }
 
 var t *envtest.Environment

--- a/pkg/controller/gittrackobject/gittrackobject_controller_suite_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_suite_test.go
@@ -21,11 +21,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kubernetes-sigs/kubebuilder/pkg/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pusher/faros/pkg/apis"
 	farosflags "github.com/pusher/faros/pkg/flags"
+	"github.com/pusher/faros/test/reporters"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -40,7 +40,7 @@ var cfg *rest.Config
 
 func TestGitTrackObjectController(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "GitTrackObject Suite", []Reporter{test.NewlineReporter{}})
+	RunSpecsWithDefaultAndCustomReporters(t, "GitTrackObject Suite", reporters.Reporters())
 }
 
 var t *envtest.Environment

--- a/pkg/controller/gittrackobject/utils/utils_suite_test.go
+++ b/pkg/controller/gittrackobject/utils/utils_suite_test.go
@@ -19,12 +19,12 @@ package utils_test
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/kubebuilder/pkg/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pusher/faros/test/reporters"
 )
 
 func TestUtils(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Utils Suite", []Reporter{test.NewlineReporter{}})
+	RunSpecsWithDefaultAndCustomReporters(t, "Utils Suite", reporters.Reporters())
 }

--- a/pkg/flags/flagset_test.go
+++ b/pkg/flags/flagset_test.go
@@ -19,15 +19,15 @@ package flags
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/kubebuilder/pkg/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pusher/faros/test/reporters"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestFlagSet(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "FlagSet Suite", []Reporter{test.NewlineReporter{}})
+	RunSpecsWithDefaultAndCustomReporters(t, "FlagSet Suite", reporters.Reporters())
 }
 
 var _ = Describe("FlagSet Suite", func() {

--- a/pkg/utils/decoder_test.go
+++ b/pkg/utils/decoder_test.go
@@ -3,17 +3,17 @@ package utils_test
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/kubebuilder/pkg/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/pusher/faros/pkg/utils"
+	"github.com/pusher/faros/test/reporters"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestDecoder(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Decoder Suite", []Reporter{test.NewlineReporter{}})
+	RunSpecsWithDefaultAndCustomReporters(t, "Decoder Suite", reporters.Reporters())
 }
 
 var roleBinding = `---

--- a/test/reporters/reporters.go
+++ b/test/reporters/reporters.go
@@ -1,0 +1,29 @@
+package reporters
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/kubernetes-sigs/kubebuilder/pkg/test"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+)
+
+var (
+	// reportDir is used to set the output directory for JUnit artifacts
+	reportDir string
+)
+
+func init() {
+	flag.StringVar(&reportDir, "report-dir", "", "Set report directory for artifact output")
+}
+
+// Reporters creates the ginkgo reporters for the test suites
+func Reporters() []ginkgo.Reporter {
+	reps := []ginkgo.Reporter{test.NewlineReporter{}}
+	if reportDir != "" {
+		reps = append(reps, reporters.NewJUnitReporter(fmt.Sprintf("%s/junit_%d.xml", reportDir, config.GinkgoConfig.ParallelNode)))
+	}
+	return reps
+}


### PR DESCRIPTION
Allows you to run `ginkgo ... -- -report-dir=...` to output JUnit XML files for parsing by Prow or other JUnit viewers