### PR TITLE
Fix JUnit reporting configuration

### DIFF
--- a/pkg/utils/client/client_suite_test.go
+++ b/pkg/utils/client/client_suite_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/glogr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pusher/faros/test/reporters"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -35,7 +36,7 @@ var cfg *rest.Config
 
 func TestMain(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Client Suite")
+	RunSpecsWithDefaultAndCustomReporters(t, "Client Suite", reporters.Reporters())
 }
 
 var t *envtest.Environment

--- a/test/reporters/reporters.go
+++ b/test/reporters/reporters.go
@@ -3,6 +3,7 @@ package reporters
 import (
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/kubernetes-sigs/kubebuilder/pkg/test"
 	"github.com/onsi/ginkgo"
@@ -21,9 +22,10 @@ func init() {
 
 // Reporters creates the ginkgo reporters for the test suites
 func Reporters() []ginkgo.Reporter {
+	now, _ := time.Now().MarshalText()
 	reps := []ginkgo.Reporter{test.NewlineReporter{}}
 	if reportDir != "" {
-		reps = append(reps, reporters.NewJUnitReporter(fmt.Sprintf("%s/junit_%d.xml", reportDir, config.GinkgoConfig.ParallelNode)))
+		reps = append(reps, reporters.NewJUnitReporter(fmt.Sprintf("%s/junit_%s_%d.xml", reportDir, string(now), config.GinkgoConfig.ParallelNode)))
 	}
 	return reps
 }


### PR DESCRIPTION
Need to make sure each test suite writes their JUnit output to an individual file, so adding the timestamp to the filename should ensure this happens

Also, missed one of the test suites 🤦‍♂️ 