### PR TITLE
Printer columns for gittracks, gittrackobjects, clustergittrackobjects

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1640,6 +1640,8 @@
     "github.com/kubernetes-sigs/kubebuilder",
     "github.com/kubernetes-sigs/kubebuilder/pkg/test",
     "github.com/onsi/ginkgo",
+    "github.com/onsi/ginkgo/config",
+    "github.com/onsi/ginkgo/reporters",
     "github.com/onsi/gomega",
     "github.com/onsi/gomega/types",
     "github.com/prometheus/client_golang/prometheus",

--- a/config/crds/faros_v1alpha1_clustergittrackobject.yaml
+++ b/config/crds/faros_v1alpha1_clustergittrackobject.yaml
@@ -6,6 +6,13 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: clustergittrackobjects.faros.pusher.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[0].status
+    name: In-Sync
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: faros.pusher.com
   names:
     kind: ClusterGitTrackObject

--- a/config/crds/faros_v1alpha1_clustergittrackobject.yaml
+++ b/config/crds/faros_v1alpha1_clustergittrackobject.yaml
@@ -7,8 +7,8 @@ metadata:
   name: clustergittrackobjects.faros.pusher.com
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.conditions[0].status
-    name: In-Sync
+  - JSONPath: .status.conditions[?(@.type=="ObjectInSync")].status
+    name: InSync
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age

--- a/config/crds/faros_v1alpha1_gittrack.yaml
+++ b/config/crds/faros_v1alpha1_gittrack.yaml
@@ -6,6 +6,28 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: gittracks.faros.pusher.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.repository
+    name: Repository
+    type: string
+  - JSONPath: .spec.reference
+    name: Reference
+    type: string
+  - JSONPath: .status.objectsApplied
+    name: objectsApplied
+    type: integer
+  - JSONPath: .status.objectsDiscovered
+    name: objectsDiscovered
+    type: integer
+  - JSONPath: .status.objectsIgnored
+    name: objectsIgnored
+    type: integer
+  - JSONPath: .status.objectsInSync
+    name: objectsInSync
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: faros.pusher.com
   names:
     kind: GitTrack

--- a/config/crds/faros_v1alpha1_gittrack.yaml
+++ b/config/crds/faros_v1alpha1_gittrack.yaml
@@ -14,16 +14,16 @@ spec:
     name: Reference
     type: string
   - JSONPath: .status.objectsApplied
-    name: Applied
+    name: ChildrenCreated
     type: integer
   - JSONPath: .status.objectsDiscovered
-    name: Discovered
+    name: ResourcesDiscovered
     type: integer
   - JSONPath: .status.objectsIgnored
-    name: Ignored
+    name: ResourcesIgnored
     type: integer
   - JSONPath: .status.objectsInSync
-    name: InSync
+    name: ChildrenInSync
     type: integer
   - JSONPath: .metadata.creationTimestamp
     name: Age

--- a/config/crds/faros_v1alpha1_gittrack.yaml
+++ b/config/crds/faros_v1alpha1_gittrack.yaml
@@ -14,16 +14,16 @@ spec:
     name: Reference
     type: string
   - JSONPath: .status.objectsApplied
-    name: objectsApplied
+    name: Applied
     type: integer
   - JSONPath: .status.objectsDiscovered
-    name: objectsDiscovered
+    name: Discovered
     type: integer
   - JSONPath: .status.objectsIgnored
-    name: objectsIgnored
+    name: Ignored
     type: integer
   - JSONPath: .status.objectsInSync
-    name: objectsInSync
+    name: InSync
     type: integer
   - JSONPath: .metadata.creationTimestamp
     name: Age

--- a/config/crds/faros_v1alpha1_gittrackobject.yaml
+++ b/config/crds/faros_v1alpha1_gittrackobject.yaml
@@ -6,6 +6,13 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: gittrackobjects.faros.pusher.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[0].status
+    name: In-Sync
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: faros.pusher.com
   names:
     kind: GitTrackObject

--- a/config/crds/faros_v1alpha1_gittrackobject.yaml
+++ b/config/crds/faros_v1alpha1_gittrackobject.yaml
@@ -7,8 +7,8 @@ metadata:
   name: gittrackobjects.faros.pusher.com
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.conditions[0].status
-    name: In-Sync
+  - JSONPath: .status.conditions[?(@.type=="ObjectInSync")].status
+    name: InSync
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age

--- a/pkg/apis/faros/v1alpha1/clustergittrackobject_types.go
+++ b/pkg/apis/faros/v1alpha1/clustergittrackobject_types.go
@@ -26,7 +26,7 @@ import (
 
 // ClusterGitTrackObject is the Schema for the clustergittrackobjects API
 // +k8s:openapi-gen=true
-// +kubebuilder:printcolumn:name="In-Sync",type="string",JSONPath=".status.conditions[0].status"
+// +kubebuilder:printcolumn:name="InSync",type="string",JSONPath=".status.conditions[?(@.type=="ObjectInSync")].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterGitTrackObject struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/faros/v1alpha1/clustergittrackobject_types.go
+++ b/pkg/apis/faros/v1alpha1/clustergittrackobject_types.go
@@ -26,6 +26,8 @@ import (
 
 // ClusterGitTrackObject is the Schema for the clustergittrackobjects API
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="In-Sync",type="string",JSONPath=".status.conditions[0].status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterGitTrackObject struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/faros/v1alpha1/gittrack_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrack_types.go
@@ -112,10 +112,10 @@ type GitTrackCondition struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="Repository",type="string",JSONPath=".spec.repository"
 // +kubebuilder:printcolumn:name="Reference",type="string",JSONPath=".spec.reference"
-// +kubebuilder:printcolumn:name="Applied",type="integer",JSONPath=".status.objectsApplied"
-// +kubebuilder:printcolumn:name="Discovered",type="integer",JSONPath=".status.objectsDiscovered"
-// +kubebuilder:printcolumn:name="Ignored",type="integer",JSONPath=".status.objectsIgnored"
-// +kubebuilder:printcolumn:name="InSync",type="integer",JSONPath=".status.objectsInSync"
+// +kubebuilder:printcolumn:name="ChildrenCreated",type="integer",JSONPath=".status.objectsApplied"
+// +kubebuilder:printcolumn:name="ResourcesDiscovered",type="integer",JSONPath=".status.objectsDiscovered"
+// +kubebuilder:printcolumn:name="ResourcesIgnored",type="integer",JSONPath=".status.objectsIgnored"
+// +kubebuilder:printcolumn:name="ChildrenInSync",type="integer",JSONPath=".status.objectsInSync"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type GitTrack struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/faros/v1alpha1/gittrack_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrack_types.go
@@ -110,6 +110,13 @@ type GitTrackCondition struct {
 
 // GitTrack is the Schema for the gittracks API
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="Repository",type="string",JSONPath=".spec.repository"
+// +kubebuilder:printcolumn:name="Reference",type="string",JSONPath=".spec.reference"
+// +kubebuilder:printcolumn:name="objectsApplied",type="integer",JSONPath=".status.objectsApplied"
+// +kubebuilder:printcolumn:name="objectsDiscovered",type="integer",JSONPath=".status.objectsDiscovered"
+// +kubebuilder:printcolumn:name="objectsIgnored",type="integer",JSONPath=".status.objectsIgnored"
+// +kubebuilder:printcolumn:name="objectsInSync",type="integer",JSONPath=".status.objectsInSync"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type GitTrack struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/faros/v1alpha1/gittrack_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrack_types.go
@@ -112,10 +112,10 @@ type GitTrackCondition struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="Repository",type="string",JSONPath=".spec.repository"
 // +kubebuilder:printcolumn:name="Reference",type="string",JSONPath=".spec.reference"
-// +kubebuilder:printcolumn:name="objectsApplied",type="integer",JSONPath=".status.objectsApplied"
-// +kubebuilder:printcolumn:name="objectsDiscovered",type="integer",JSONPath=".status.objectsDiscovered"
-// +kubebuilder:printcolumn:name="objectsIgnored",type="integer",JSONPath=".status.objectsIgnored"
-// +kubebuilder:printcolumn:name="objectsInSync",type="integer",JSONPath=".status.objectsInSync"
+// +kubebuilder:printcolumn:name="Applied",type="integer",JSONPath=".status.objectsApplied"
+// +kubebuilder:printcolumn:name="Discovered",type="integer",JSONPath=".status.objectsDiscovered"
+// +kubebuilder:printcolumn:name="Ignored",type="integer",JSONPath=".status.objectsIgnored"
+// +kubebuilder:printcolumn:name="InSync",type="integer",JSONPath=".status.objectsInSync"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type GitTrack struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/faros/v1alpha1/gittrackobject_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrackobject_types.go
@@ -75,7 +75,7 @@ type GitTrackObjectCondition struct {
 
 // GitTrackObject is the Schema for the gittrackobjects API
 // +k8s:openapi-gen=true
-// +kubebuilder:printcolumn:name="In-Sync",type="string",JSONPath=".status.conditions[0].status"
+// +kubebuilder:printcolumn:name="InSync",type="string",JSONPath=".status.conditions[?(@.type=="ObjectInSync")].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type GitTrackObject struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/faros/v1alpha1/gittrackobject_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrackobject_types.go
@@ -75,6 +75,8 @@ type GitTrackObjectCondition struct {
 
 // GitTrackObject is the Schema for the gittrackobjects API
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="In-Sync",type="string",JSONPath=".status.conditions[0].status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type GitTrackObject struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Adds [additional printer columns](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#additional-printer-columns) to Faros CRDs. 