### PR TITLE
Hide some CRD columns under `-o wide` flag

### DIFF
--- a/config/crds/faros_v1alpha1_clustergittrackobject.yaml
+++ b/config/crds/faros_v1alpha1_clustergittrackobject.yaml
@@ -12,7 +12,6 @@ spec:
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age
-    priority: 1
     type: date
   group: faros.pusher.com
   names:

--- a/config/crds/faros_v1alpha1_clustergittrackobject.yaml
+++ b/config/crds/faros_v1alpha1_clustergittrackobject.yaml
@@ -12,6 +12,7 @@ spec:
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age
+    priority: 1
     type: date
   group: faros.pusher.com
   names:

--- a/config/crds/faros_v1alpha1_clustergittrackobject.yaml
+++ b/config/crds/faros_v1alpha1_clustergittrackobject.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="ObjectInSync")].status
-    name: InSync
+    name: In Sync
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age

--- a/config/crds/faros_v1alpha1_gittrack.yaml
+++ b/config/crds/faros_v1alpha1_gittrack.yaml
@@ -9,6 +9,7 @@ spec:
   additionalPrinterColumns:
   - JSONPath: .spec.repository
     name: Repository
+    priority: 1
     type: string
   - JSONPath: .spec.reference
     name: Reference
@@ -27,6 +28,7 @@ spec:
     type: integer
   - JSONPath: .metadata.creationTimestamp
     name: Age
+    priority: 1
     type: date
   group: faros.pusher.com
   names:

--- a/config/crds/faros_v1alpha1_gittrack.yaml
+++ b/config/crds/faros_v1alpha1_gittrack.yaml
@@ -15,16 +15,16 @@ spec:
     name: Reference
     type: string
   - JSONPath: .status.objectsApplied
-    name: ChildrenCreated
+    name: Children Created
     type: integer
   - JSONPath: .status.objectsDiscovered
-    name: ResourcesDiscovered
+    name: Resources Discovered
     type: integer
   - JSONPath: .status.objectsIgnored
-    name: ResourcesIgnored
+    name: Resources Ignored
     type: integer
   - JSONPath: .status.objectsInSync
-    name: ChildrenInSync
+    name: Children In Sync
     type: integer
   - JSONPath: .metadata.creationTimestamp
     name: Age

--- a/config/crds/faros_v1alpha1_gittrack.yaml
+++ b/config/crds/faros_v1alpha1_gittrack.yaml
@@ -28,7 +28,6 @@ spec:
     type: integer
   - JSONPath: .metadata.creationTimestamp
     name: Age
-    priority: 1
     type: date
   group: faros.pusher.com
   names:

--- a/config/crds/faros_v1alpha1_gittrackobject.yaml
+++ b/config/crds/faros_v1alpha1_gittrackobject.yaml
@@ -12,7 +12,6 @@ spec:
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age
-    priority: 1
     type: date
   group: faros.pusher.com
   names:

--- a/config/crds/faros_v1alpha1_gittrackobject.yaml
+++ b/config/crds/faros_v1alpha1_gittrackobject.yaml
@@ -12,6 +12,7 @@ spec:
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age
+    priority: 1
     type: date
   group: faros.pusher.com
   names:

--- a/config/crds/faros_v1alpha1_gittrackobject.yaml
+++ b/config/crds/faros_v1alpha1_gittrackobject.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="ObjectInSync")].status
-    name: InSync
+    name: In Sync
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age

--- a/pkg/apis/faros/v1alpha1/clustergittrackobject_types.go
+++ b/pkg/apis/faros/v1alpha1/clustergittrackobject_types.go
@@ -27,7 +27,7 @@ import (
 // ClusterGitTrackObject is the Schema for the clustergittrackobjects API
 // +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="InSync",type="string",JSONPath=".status.conditions[?(@.type=="ObjectInSync")].status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=1
 type ClusterGitTrackObject struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/faros/v1alpha1/clustergittrackobject_types.go
+++ b/pkg/apis/faros/v1alpha1/clustergittrackobject_types.go
@@ -27,7 +27,7 @@ import (
 // ClusterGitTrackObject is the Schema for the clustergittrackobjects API
 // +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="In Sync",type="string",JSONPath=".status.conditions[?(@.type=="ObjectInSync")].status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=1
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterGitTrackObject struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/faros/v1alpha1/clustergittrackobject_types.go
+++ b/pkg/apis/faros/v1alpha1/clustergittrackobject_types.go
@@ -26,7 +26,7 @@ import (
 
 // ClusterGitTrackObject is the Schema for the clustergittrackobjects API
 // +k8s:openapi-gen=true
-// +kubebuilder:printcolumn:name="InSync",type="string",JSONPath=".status.conditions[?(@.type=="ObjectInSync")].status"
+// +kubebuilder:printcolumn:name="In Sync",type="string",JSONPath=".status.conditions[?(@.type=="ObjectInSync")].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=1
 type ClusterGitTrackObject struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/faros/v1alpha1/gittrack_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrack_types.go
@@ -130,7 +130,7 @@ type GitTrackCondition struct {
 // +kubebuilder:printcolumn:name="Resources Discovered",type="integer",JSONPath=".status.objectsDiscovered"
 // +kubebuilder:printcolumn:name="Resources Ignored",type="integer",JSONPath=".status.objectsIgnored"
 // +kubebuilder:printcolumn:name="Children In Sync",type="integer",JSONPath=".status.objectsInSync"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=1
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type GitTrack struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/faros/v1alpha1/gittrack_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrack_types.go
@@ -126,10 +126,10 @@ type GitTrackCondition struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="Repository",type="string",JSONPath=".spec.repository",priority=1
 // +kubebuilder:printcolumn:name="Reference",type="string",JSONPath=".spec.reference"
-// +kubebuilder:printcolumn:name="ChildrenCreated",type="integer",JSONPath=".status.objectsApplied"
-// +kubebuilder:printcolumn:name="ResourcesDiscovered",type="integer",JSONPath=".status.objectsDiscovered"
-// +kubebuilder:printcolumn:name="ResourcesIgnored",type="integer",JSONPath=".status.objectsIgnored"
-// +kubebuilder:printcolumn:name="ChildrenInSync",type="integer",JSONPath=".status.objectsInSync"
+// +kubebuilder:printcolumn:name="Children Created",type="integer",JSONPath=".status.objectsApplied"
+// +kubebuilder:printcolumn:name="Resources Discovered",type="integer",JSONPath=".status.objectsDiscovered"
+// +kubebuilder:printcolumn:name="Resources Ignored",type="integer",JSONPath=".status.objectsIgnored"
+// +kubebuilder:printcolumn:name="Children In Sync",type="integer",JSONPath=".status.objectsInSync"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=1
 type GitTrack struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/faros/v1alpha1/gittrack_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrack_types.go
@@ -124,13 +124,13 @@ type GitTrackCondition struct {
 
 // GitTrack is the Schema for the gittracks API
 // +k8s:openapi-gen=true
-// +kubebuilder:printcolumn:name="Repository",type="string",JSONPath=".spec.repository"
+// +kubebuilder:printcolumn:name="Repository",type="string",JSONPath=".spec.repository",priority=1
 // +kubebuilder:printcolumn:name="Reference",type="string",JSONPath=".spec.reference"
 // +kubebuilder:printcolumn:name="ChildrenCreated",type="integer",JSONPath=".status.objectsApplied"
 // +kubebuilder:printcolumn:name="ResourcesDiscovered",type="integer",JSONPath=".status.objectsDiscovered"
 // +kubebuilder:printcolumn:name="ResourcesIgnored",type="integer",JSONPath=".status.objectsIgnored"
 // +kubebuilder:printcolumn:name="ChildrenInSync",type="integer",JSONPath=".status.objectsInSync"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=1
 type GitTrack struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/faros/v1alpha1/gittrackobject_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrackobject_types.go
@@ -76,7 +76,7 @@ type GitTrackObjectCondition struct {
 // GitTrackObject is the Schema for the gittrackobjects API
 // +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="InSync",type="string",JSONPath=".status.conditions[?(@.type=="ObjectInSync")].status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=1
 type GitTrackObject struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/faros/v1alpha1/gittrackobject_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrackobject_types.go
@@ -76,7 +76,7 @@ type GitTrackObjectCondition struct {
 // GitTrackObject is the Schema for the gittrackobjects API
 // +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="In Sync",type="string",JSONPath=".status.conditions[?(@.type=="ObjectInSync")].status"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=1
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type GitTrackObject struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/faros/v1alpha1/gittrackobject_types.go
+++ b/pkg/apis/faros/v1alpha1/gittrackobject_types.go
@@ -75,7 +75,7 @@ type GitTrackObjectCondition struct {
 
 // GitTrackObject is the Schema for the gittrackobjects API
 // +k8s:openapi-gen=true
-// +kubebuilder:printcolumn:name="InSync",type="string",JSONPath=".status.conditions[?(@.type=="ObjectInSync")].status"
+// +kubebuilder:printcolumn:name="In Sync",type="string",JSONPath=".status.conditions[?(@.type=="ObjectInSync")].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=1
 type GitTrackObject struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
The output from `kubectl get ...` becomes rather wide with the additional ones added in #105, and this PR hides the "Repository" and "Age" columns by default under the `-o wide` flag.

I also took the liberty of adding spaces to the camelcased columns and reordered the columns for GitTracks.

Example:

```
# before
$ kubectl get gts --all-namespaces
NAMESPACE   NAME   REPOSITORY   REFERENCE   CHILDRENCREATED   RESOURCESDISCOVERED   RESOURCESIGNORED   CHILDRENINSYNC   AGE

# after
$ kubectl get gts --all-namespaces
NAMESPACE   NAME   REFERENCE   RESOURCES   DISCOVERED   CHILDREN CREATED   CHILDREN IN SYNC   RESOURCES IGNORED
```

Thoughts?