### PR TITLE
Improve debug logging

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -193,14 +193,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:6c280b44782900265b0827ceb9a7f9982dd15f183f05107b73cc06c65c8dc5b6"
-  name = "github.com/go-logr/glogr"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "03aa3c3200582c33f271f63ba3ae7d23abb9e699"
-  version = "v0.1.0"
-
-[[projects]]
   branch = "master"
   digest = "1:65587005c6fa4293c0b8a2e457e689df7fda48cc5e1f5449ea2c1e7784551558"
   name = "github.com/go-logr/logr"
@@ -1461,7 +1453,10 @@
 [[projects]]
   digest = "1:ed9fcc00d9b154265b72e4117e7e41c4af049bf2c4a7ee9171960f938ff1ca65"
   name = "k8s.io/klog"
-  packages = ["."]
+  packages = [
+    ".",
+    "klogr",
+  ]
   pruneopts = "T"
   revision = "71442cd4037d612096940ceb0f3fec3f7fff66e0"
   version = "v0.2.0"
@@ -1518,7 +1513,7 @@
   revision = "c2654d5206da6b7b6ace12841e8f359bb89b443c"
 
 [[projects]]
-  digest = "1:97d80be126d2265e0e127658a91b4c40b8eedcf217104e015cd424e694b485a4"
+  digest = "1:95ffb16725c38eee5c646a7cbb60bd433c5e05443022fa21ccfc6bcf55c3a9d1"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -1557,7 +1552,8 @@
     "pkg/webhook/internal/metrics",
   ]
   pruneopts = "T"
-  revision = "e4c40bc20113bec130047ba0a42cec39ca0d6476"
+  revision = "4276f3895df0acc9249f817eb86a47a3db6b7a9e"
+  version = "v0.2.0-alpha.0"
 
 [[projects]]
   digest = "1:2aec1bbf1553a2d433b3a85f9359930655de83e2dceed4aca44577a720396da8"
@@ -1631,7 +1627,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/emicklei/go-restful",
-    "github.com/go-logr/glogr",
+    "github.com/go-logr/logr",
     "github.com/jonboulle/clockwork",
     "github.com/kubernetes-sigs/kubebuilder",
     "github.com/kubernetes-sigs/kubebuilder/pkg/test",
@@ -1683,6 +1679,8 @@
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/client-go/util/workqueue",
     "k8s.io/code-generator/cmd/deepcopy-gen",
+    "k8s.io/klog",
+    "k8s.io/klog/klogr",
     "k8s.io/kube-openapi/pkg/util/proto",
     "k8s.io/kubernetes/pkg/kubectl/cmd/util",
     "k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@ revision="0689ccc1d7d65d9dd1bedcc3b0b1ed7df91ba266"
 
 [[override]]
 name="sigs.k8s.io/controller-runtime"
-revision="e4c40bc20113bec130047ba0a42cec39ca0d6476"
+version="v0.2.0-alpha.0"
 
 [[override]]
 name="sigs.k8s.io/controller-tools"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -72,6 +72,11 @@ func main() {
 		klog.CopyStandardLogTo("INFO")
 		klog.SetOutput(os.Stderr)
 		klog.SetOutputBySeverity("INFO", os.Stdout)
+		err := logFlags.Lookup("stderrthreshold").Value.Set("WARNING")
+		if err != nil {
+			log.Error(err, "unable to set `stderrthreshold`")
+			panic(err)
+		}
 	}
 
 	// Get a config to talk to the apiserver

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"runtime"
 	"time"
 
@@ -30,8 +29,11 @@ import (
 	"github.com/pusher/faros/pkg/utils"
 	flag "github.com/spf13/pflag"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logr "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
@@ -45,10 +47,15 @@ var (
 )
 
 func main() {
+	logr.SetLogger(klogr.New())
+	log := logr.Log.WithName("manager")
+	logFlags := &goflag.FlagSet{}
+	klog.InitFlags(logFlags)
+
 	// Setup flags
 	goflag.Lookup("logtostderr").Value.Set("true")
 	flag.CommandLine.AddFlagSet(farosflags.FlagSet)
-	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	flag.CommandLine.AddGoFlagSet(logFlags)
 	flag.Parse()
 
 	// Handle version flag
@@ -60,7 +67,8 @@ func main() {
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "invalid config")
+		panic(err)
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
@@ -74,23 +82,30 @@ func main() {
 		MapperProvider:          utils.NewRestMapper,
 	})
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "failed to initalise manager")
+		panic(err)
 	}
 
-	log.Printf("Registering Components.")
+	log.V(0).Info("Registering Components.")
 
 	// Setup Scheme for all resources
-	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatal(err)
+	if err = apis.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "couldn't register APIs")
+		panic(err)
 	}
 
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr); err != nil {
-		log.Fatal(err)
+	if err = controller.AddToManager(mgr); err != nil {
+		log.Error(err, "couldn't register controllers")
+		panic(err)
 	}
 
-	log.Printf("Starting the Cmd.")
+	log.V(0).Info("Starting controllers...")
 
 	// Start the Cmd
-	log.Fatal(mgr.Start(signals.SetupSignalHandler()))
+	err = mgr.Start(signals.SetupSignalHandler())
+	if err != nil {
+		log.Error(err, "controller error")
+		panic(err)
+	}
 }

--- a/pkg/controller/gittrack/gittrack_controller.go
+++ b/pkg/controller/gittrack/gittrack_controller.go
@@ -392,7 +392,7 @@ func (r *ReconcileGitTrack) handleObject(u *unstructured.Unstructured, owner *fa
 	}
 	if childUpdated {
 		inSync = false
-		r.log.V(0).Info("Child updated", "ChildName", name)
+		r.log.V(0).Info("Child updated", "child name", name)
 		r.recorder.Eventf(owner, apiv1.EventTypeNormal, "UpdateSuccessful", "Updated child '%s'", name)
 	}
 	return successResult(gto.GetNamespacedName(), timeToDeploy, inSync)
@@ -414,7 +414,7 @@ func (r *ReconcileGitTrack) createChild(name string, timeToDeploy time.Duration,
 		return errorResult(childGTO.GetNamespacedName(), fmt.Errorf("failed to create child for '%s': %v", name, err))
 	}
 	r.recorder.Eventf(owner, apiv1.EventTypeNormal, "CreateSuccessful", "Created child '%s'", name)
-	r.log.V(0).Info("Child created", "ChildName", name)
+	r.log.V(0).Info("Child created", "child name", name)
 	return successResult(childGTO.GetNamespacedName(), timeToDeploy, false)
 }
 
@@ -441,7 +441,7 @@ func (r *ReconcileGitTrack) deleteResources(leftovers map[string]farosv1alpha1.G
 		if err := r.Delete(context.TODO(), obj); err != nil {
 			return fmt.Errorf("failed to delete child for '%s': '%s'", name, err)
 		}
-		r.log.V(0).Info("Deleted child", "ChildName", name)
+		r.log.V(0).Info("Child deleted", "child name", name)
 	}
 	return nil
 }
@@ -508,8 +508,8 @@ func (r *ReconcileGitTrack) Reconcile(request reconcile.Request) (reconcile.Resu
 	}
 
 	reconciler := r.withValues(
-		"Namespace", instance.GetNamespace(),
-		"Name", instance.GetName(),
+		"namespace", instance.GetNamespace(),
+		"name", instance.GetName(),
 	)
 	reconciler.log.V(1).Info("Reconcile started")
 

--- a/pkg/controller/gittrack/gittrack_controller.go
+++ b/pkg/controller/gittrack/gittrack_controller.go
@@ -146,7 +146,7 @@ func (r *ReconcileGitTrack) withValues(keysAndValues ...interface{}) *ReconcileG
 
 // checkoutRepo checks out the repository at reference and returns a pointer to said repository
 func (r *ReconcileGitTrack) checkoutRepo(url string, ref string, gitCreds *gitCredentials) (*gitstore.Repo, error) {
-	r.log.V(4).Info("Getting repository", "url", url)
+	r.log.V(1).Info("Getting repository", "url", url)
 	repoRef, err := createRepoRefFromCreds(url, gitCreds)
 	if err != nil {
 		return &gitstore.Repo{}, err
@@ -156,7 +156,7 @@ func (r *ReconcileGitTrack) checkoutRepo(url string, ref string, gitCreds *gitCr
 		return &gitstore.Repo{}, fmt.Errorf("failed to get repository '%s': %v'", url, err)
 	}
 
-	r.log.V(2).Info("Checking out reference", "ref", ref)
+	r.log.V(1).Info("Checking out reference", "ref", ref)
 	err = repo.Checkout(ref)
 	if err != nil {
 		return &gitstore.Repo{}, fmt.Errorf("failed to checkout '%s': %v", ref, err)
@@ -392,7 +392,7 @@ func (r *ReconcileGitTrack) handleObject(u *unstructured.Unstructured, owner *fa
 	}
 	if childUpdated {
 		inSync = false
-		r.log.V(2).Info("Child updated", "ChildName", name)
+		r.log.V(0).Info("Child updated", "ChildName", name)
 		r.recorder.Eventf(owner, apiv1.EventTypeNormal, "UpdateSuccessful", "Updated child '%s'", name)
 	}
 	return successResult(gto.GetNamespacedName(), timeToDeploy, inSync)
@@ -414,7 +414,7 @@ func (r *ReconcileGitTrack) createChild(name string, timeToDeploy time.Duration,
 		return errorResult(childGTO.GetNamespacedName(), fmt.Errorf("failed to create child for '%s': %v", name, err))
 	}
 	r.recorder.Eventf(owner, apiv1.EventTypeNormal, "CreateSuccessful", "Created child '%s'", name)
-	r.log.V(2).Info("Child created", "ChildName", name)
+	r.log.V(0).Info("Child created", "ChildName", name)
 	return successResult(childGTO.GetNamespacedName(), timeToDeploy, false)
 }
 
@@ -441,7 +441,7 @@ func (r *ReconcileGitTrack) deleteResources(leftovers map[string]farosv1alpha1.G
 		if err := r.Delete(context.TODO(), obj); err != nil {
 			return fmt.Errorf("failed to delete child for '%s': '%s'", name, err)
 		}
-		r.log.V(2).Info("Deleted child", "ChildName", name)
+		r.log.V(0).Info("Deleted child", "ChildName", name)
 	}
 	return nil
 }
@@ -511,7 +511,7 @@ func (r *ReconcileGitTrack) Reconcile(request reconcile.Request) (reconcile.Resu
 		"Namespace", instance.GetNamespace(),
 		"Name", instance.GetName(),
 	)
-	reconciler.log.V(2).Info("Reconcile started")
+	reconciler.log.V(1).Info("Reconcile started")
 
 	sOpts := newStatusOpts()
 	mOpts := newMetricOpts(sOpts)
@@ -521,7 +521,7 @@ func (r *ReconcileGitTrack) Reconcile(request reconcile.Request) (reconcile.Resu
 		err := reconciler.updateStatus(instance, sOpts)
 		mErr := reconciler.updateMetrics(instance, mOpts)
 
-		reconciler.log.V(2).Info("Reconcile finished")
+		reconciler.log.V(1).Info("Reconcile finished")
 		// Print out any errors that may have occurred
 		for _, e := range []error{
 			err,

--- a/pkg/controller/gittrack/gittrack_controller_suite_test.go
+++ b/pkg/controller/gittrack/gittrack_controller_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gittrack
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -32,9 +33,12 @@ import (
 	"github.com/pusher/faros/test/reporters"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logr "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var cfg *rest.Config
@@ -61,7 +65,7 @@ func teardownRepository(dir string) {
 	os.RemoveAll(dir)
 }
 
-func TestBee(t *testing.T) {
+func TestMain(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecsWithDefaultAndCustomReporters(t, "GitTrack Suite", reporters.Reporters())
 }
@@ -69,6 +73,12 @@ func TestBee(t *testing.T) {
 var t *envtest.Environment
 
 var _ = BeforeSuite(func() {
+	logr.SetLogger(klogr.New())
+	logFlags := &flag.FlagSet{}
+	klog.InitFlags(logFlags)
+	// Set log level high for tests
+	logFlags.Lookup("v").Value.Set("4")
+
 	t = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
 	}

--- a/pkg/controller/gittrack/status.go
+++ b/pkg/controller/gittrack/status.go
@@ -19,7 +19,6 @@ package gittrack
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
 
 	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
@@ -106,11 +105,11 @@ func (r *ReconcileGitTrack) updateStatus(original *farosv1alpha1.GitTrack, opts 
 
 	// If the status was modified, update the GitTrack on the API
 	if gtUpdated {
-		log.Printf("Updating GitTrack %s status", gt.Name)
 		err := r.Update(context.TODO(), gt)
 		if err != nil {
 			return fmt.Errorf("unable to update GitTrack: %v", err)
 		}
+		r.log.V(2).Info("Status updated")
 	}
 	return nil
 }

--- a/pkg/controller/gittrack/status.go
+++ b/pkg/controller/gittrack/status.go
@@ -109,7 +109,7 @@ func (r *ReconcileGitTrack) updateStatus(original *farosv1alpha1.GitTrack, opts 
 		if err != nil {
 			return fmt.Errorf("unable to update GitTrack: %v", err)
 		}
-		r.log.V(2).Info("Status updated")
+		r.log.V(1).Info("Status updated")
 	}
 	return nil
 }

--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -27,6 +27,7 @@ import (
 	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
 	gittrackobjectutils "github.com/pusher/faros/pkg/controller/gittrackobject/utils"
 
+	"github.com/go-logr/logr"
 	"github.com/pusher/faros/pkg/utils"
 	farosclient "github.com/pusher/faros/pkg/utils/client"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -40,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	rlogr "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -82,6 +84,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		recorder:       mgr.GetEventRecorderFor("gittrackobject-controller"),
 		applier:        applier,
 		dryRunVerifier: dryRunVerifier,
+		log:            rlogr.Log.WithName("gittrackobject-controller"),
 	}
 }
 
@@ -158,6 +161,7 @@ type ReconcileGitTrackObject struct {
 	config      *rest.Config
 	stop        chan struct{}
 	recorder    record.EventRecorder
+	log         logr.Logger
 
 	applier        farosclient.Client
 	dryRunVerifier *utils.DryRunVerifier
@@ -171,6 +175,12 @@ func (r *ReconcileGitTrackObject) EventStream() chan event.GenericEvent {
 // StopChan returns the object stop channel
 func (r *ReconcileGitTrackObject) StopChan() chan struct{} {
 	return r.stop
+}
+
+func (r *ReconcileGitTrackObject) withValues(keysAndValues ...interface{}) *ReconcileGitTrackObject {
+	reconciler := *r
+	reconciler.log = r.log.WithValues(keysAndValues...)
+	return &reconciler
 }
 
 // Reconcile reads that state of the cluster for a GitTrackObject object and makes changes based on the state read
@@ -191,12 +201,22 @@ func (r *ReconcileGitTrackObject) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
-	// Create new opts structs for updating status and metrics
-	result := r.handleGitTrackObject(instance)
-	r.updateStatus(instance, &statusOpts{inSyncError: result.inSyncError, inSyncReason: result.inSyncReason})
-	inSync := result.inSyncError == nil
-	r.updateMetrics(instance, &metricsOpts{inSync: inSync})
+	// Get a reconciler with appropriate logging values
+	reconciler := r.withValues(
+		"Namespace", instance.GetNamespace(),
+		"ChildName", instance.GetSpec().Name,
+		"ChildKind", instance.GetSpec().Kind,
+	)
 
+	reconciler.log.V(3).Info("Reconcile started")
+
+	// Create new opts structs for updating status and metrics
+	result := reconciler.handleGitTrackObject(instance)
+	reconciler.updateStatus(instance, &statusOpts{inSyncError: result.inSyncError, inSyncReason: result.inSyncReason})
+	inSync := result.inSyncError == nil
+	reconciler.updateMetrics(instance, &metricsOpts{inSync: inSync})
+
+	reconciler.log.V(3).Info("Reconcile finished")
 	return reconcile.Result{}, result.inSyncError
 }
 

--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -129,6 +129,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 					IsController: true,
 					OwnerType:    &farosv1alpha1.ClusterGitTrackObject{},
 				},
+				Log: rlogr.Log.WithName("gittrackobject-controller/enqueue-request-for-owner"),
 			},
 			utils.NewOwnersOwnerInNamespacePredicate(mgr.GetClient()),
 		)

--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -197,10 +197,6 @@ func (r *ReconcileGitTrackObject) Reconcile(request reconcile.Request) (reconcil
 	inSync := result.inSyncError == nil
 	r.updateMetrics(instance, &metricsOpts{inSync: inSync})
 
-	if result.inSyncError != nil {
-		log.Printf("error syncing child %s: %v", instance.GetNamespacedName(), result.inSyncError)
-	}
-
 	return reconcile.Result{}, result.inSyncError
 }
 

--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -209,7 +209,7 @@ func (r *ReconcileGitTrackObject) Reconcile(request reconcile.Request) (reconcil
 		"ChildKind", instance.GetSpec().Kind,
 	)
 
-	reconciler.log.V(3).Info("Reconcile started")
+	reconciler.log.V(1).Info("Reconcile started")
 
 	// Create new opts structs for updating status and metrics
 	result := reconciler.handleGitTrackObject(instance)
@@ -217,7 +217,7 @@ func (r *ReconcileGitTrackObject) Reconcile(request reconcile.Request) (reconcil
 	inSync := result.inSyncError == nil
 	reconciler.updateMetrics(instance, &metricsOpts{inSync: inSync})
 
-	reconciler.log.V(3).Info("Reconcile finished")
+	reconciler.log.V(1).Info("Reconcile finished")
 	return reconcile.Result{}, result.inSyncError
 }
 

--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -204,9 +204,9 @@ func (r *ReconcileGitTrackObject) Reconcile(request reconcile.Request) (reconcil
 
 	// Get a reconciler with appropriate logging values
 	reconciler := r.withValues(
-		"Namespace", instance.GetNamespace(),
-		"ChildName", instance.GetSpec().Name,
-		"ChildKind", instance.GetSpec().Kind,
+		"namespace", instance.GetNamespace(),
+		"child name", instance.GetSpec().Name,
+		"child kind", instance.GetSpec().Kind,
 	)
 
 	reconciler.log.V(1).Info("Reconcile started")

--- a/pkg/controller/gittrackobject/gittrackobject_controller_suite_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gittrackobject
 
 import (
+	"flag"
 	"log"
 	"path/filepath"
 	"sync"
@@ -32,9 +33,12 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logr "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var cfg *rest.Config
@@ -47,6 +51,12 @@ func TestGitTrackObjectController(t *testing.T) {
 var t *envtest.Environment
 
 var _ = BeforeSuite(func() {
+	logr.SetLogger(klogr.New())
+	logFlags := &flag.FlagSet{}
+	klog.InitFlags(logFlags)
+	// Set log level high for tests
+	logFlags.Lookup("v").Value.Set("4")
+
 	t = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
 	}

--- a/pkg/controller/gittrackobject/handler.go
+++ b/pkg/controller/gittrackobject/handler.go
@@ -176,7 +176,7 @@ func (r *ReconcileGitTrackObject) handleDefaultUpdateStrategy(gto farosv1alpha1.
 
 	// Update was successful
 	r.sendEvent(gto, corev1.EventTypeNormal, "UpdateSuccessful", "Successfully updated child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
-	r.log.V(0).Info("Child Updated")
+	r.log.V(0).Info("Child updated")
 	return "", nil
 }
 
@@ -208,7 +208,7 @@ func (r *ReconcileGitTrackObject) handleRecreateUpdateStrategy(gto farosv1alpha1
 
 	// Update was successful
 	r.sendEvent(gto, corev1.EventTypeNormal, "UpdateSuccessful", "Successfully updated child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
-	r.log.V(0).Info("Child Updated")
+	r.log.V(0).Info("Child updated")
 	return "", nil
 }
 

--- a/pkg/controller/gittrackobject/handler.go
+++ b/pkg/controller/gittrackobject/handler.go
@@ -19,7 +19,6 @@ package gittrackobject
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
 
 	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
@@ -132,7 +131,6 @@ func (r *ReconcileGitTrackObject) getChildFromGitTrackObject(gto farosv1alpha1.G
 // handleCreate takes an unstructured object sends it to the API to create it
 func (r *ReconcileGitTrackObject) handleCreate(gto farosv1alpha1.GitTrackObjectInterface, child *unstructured.Unstructured) (gittrackobjectutils.ConditionReason, error) {
 	// Log and send event that we are attempting to create the child resource
-	log.Printf("Creating child %s %s/%s\n", child.GetKind(), child.GetNamespace(), child.GetName())
 	r.sendEvent(gto, corev1.EventTypeNormal, "CreateStarted", "Creating child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
 
 	err := r.applier.Apply(context.TODO(), &farosclient.ApplyOptions{}, child)
@@ -140,6 +138,8 @@ func (r *ReconcileGitTrackObject) handleCreate(gto farosv1alpha1.GitTrackObjectI
 		r.sendEvent(gto, corev1.EventTypeWarning, "CreateFailed", "Failed to create child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
 		return gittrackobjectutils.ErrorCreatingChild, fmt.Errorf("unable to create child: %v", err)
 	}
+
+	r.log.V(2).Info("Child created")
 
 	// Successfully created the child object
 	r.sendEvent(gto, corev1.EventTypeNormal, "CreateSuccessful", "Successfully created child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
@@ -176,13 +176,14 @@ func (r *ReconcileGitTrackObject) handleDefaultUpdateStrategy(gto farosv1alpha1.
 
 	// Update was successful
 	r.sendEvent(gto, corev1.EventTypeNormal, "UpdateSuccessful", "Successfully updated child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
-	log.Printf("Updated child %s %s/%s\n", child.GetKind(), child.GetNamespace(), child.GetName())
+	r.log.V(2).Info("Child Updated")
 	return "", nil
 }
 
 // handleNeverUpdateStrategy compares the existing object to the existing object
 // with the correct owner references applied and updates if necessary
 func (r *ReconcileGitTrackObject) handleNeverUpdateStrategy(gto farosv1alpha1.GitTrackObjectInterface, found *unstructured.Unstructured) (gittrackobjectutils.ConditionReason, error) {
+	r.log.V(4).Info("Child has `never` update strategy")
 	child := found.DeepCopy()
 	err := controllerutil.SetControllerReference(gto, child, r.scheme)
 	if err != nil {
@@ -195,6 +196,7 @@ func (r *ReconcileGitTrackObject) handleNeverUpdateStrategy(gto farosv1alpha1.Gi
 // resources and then deletes and recreates the child object if an update is
 // required
 func (r *ReconcileGitTrackObject) handleRecreateUpdateStrategy(gto farosv1alpha1.GitTrackObjectInterface, found, child *unstructured.Unstructured) (gittrackobjectutils.ConditionReason, error) {
+	r.log.V(4).Info("Child has `recreate` update strategy")
 	childUpdated, err := r.recreateChild(found, child)
 	if err != nil {
 		r.sendEvent(gto, corev1.EventTypeWarning, "UpdateFailed", "Unable to update child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
@@ -206,7 +208,7 @@ func (r *ReconcileGitTrackObject) handleRecreateUpdateStrategy(gto farosv1alpha1
 
 	// Update was successful
 	r.sendEvent(gto, corev1.EventTypeNormal, "UpdateSuccessful", "Successfully updated child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
-	log.Printf("Updated child %s %s/%s\n", child.GetKind(), child.GetNamespace(), child.GetName())
+	r.log.V(2).Info("Child Updated")
 	return "", nil
 }
 
@@ -222,10 +224,12 @@ func (r *ReconcileGitTrackObject) updateChild(found, child *unstructured.Unstruc
 	// HasSupport returns an error if dry run not supported
 	if farosflags.ServerDryRun {
 		if err := r.dryRunVerifier.HasSupport(child.GroupVersionKind()); err == nil {
+			r.log.V(5).Info("Updating child with dry-run support")
 			return r.applyChildWithDryRun(found, child, false)
 		}
 	}
 	// Dry run not supported so apply without DryRun
+	r.log.V(5).Info("Updating child without dry-run support")
 	return r.applyChild(found, child, false)
 }
 

--- a/pkg/controller/gittrackobject/handler.go
+++ b/pkg/controller/gittrackobject/handler.go
@@ -139,7 +139,7 @@ func (r *ReconcileGitTrackObject) handleCreate(gto farosv1alpha1.GitTrackObjectI
 		return gittrackobjectutils.ErrorCreatingChild, fmt.Errorf("unable to create child: %v", err)
 	}
 
-	r.log.V(2).Info("Child created")
+	r.log.V(0).Info("Child created")
 
 	// Successfully created the child object
 	r.sendEvent(gto, corev1.EventTypeNormal, "CreateSuccessful", "Successfully created child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
@@ -176,14 +176,14 @@ func (r *ReconcileGitTrackObject) handleDefaultUpdateStrategy(gto farosv1alpha1.
 
 	// Update was successful
 	r.sendEvent(gto, corev1.EventTypeNormal, "UpdateSuccessful", "Successfully updated child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
-	r.log.V(2).Info("Child Updated")
+	r.log.V(0).Info("Child Updated")
 	return "", nil
 }
 
 // handleNeverUpdateStrategy compares the existing object to the existing object
 // with the correct owner references applied and updates if necessary
 func (r *ReconcileGitTrackObject) handleNeverUpdateStrategy(gto farosv1alpha1.GitTrackObjectInterface, found *unstructured.Unstructured) (gittrackobjectutils.ConditionReason, error) {
-	r.log.V(4).Info("Child has `never` update strategy")
+	r.log.V(1).Info("Child has `never` update strategy")
 	child := found.DeepCopy()
 	err := controllerutil.SetControllerReference(gto, child, r.scheme)
 	if err != nil {
@@ -196,7 +196,7 @@ func (r *ReconcileGitTrackObject) handleNeverUpdateStrategy(gto farosv1alpha1.Gi
 // resources and then deletes and recreates the child object if an update is
 // required
 func (r *ReconcileGitTrackObject) handleRecreateUpdateStrategy(gto farosv1alpha1.GitTrackObjectInterface, found, child *unstructured.Unstructured) (gittrackobjectutils.ConditionReason, error) {
-	r.log.V(4).Info("Child has `recreate` update strategy")
+	r.log.V(1).Info("Child has `recreate` update strategy")
 	childUpdated, err := r.recreateChild(found, child)
 	if err != nil {
 		r.sendEvent(gto, corev1.EventTypeWarning, "UpdateFailed", "Unable to update child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
@@ -208,7 +208,7 @@ func (r *ReconcileGitTrackObject) handleRecreateUpdateStrategy(gto farosv1alpha1
 
 	// Update was successful
 	r.sendEvent(gto, corev1.EventTypeNormal, "UpdateSuccessful", "Successfully updated child %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName())
-	r.log.V(2).Info("Child Updated")
+	r.log.V(0).Info("Child Updated")
 	return "", nil
 }
 
@@ -224,12 +224,12 @@ func (r *ReconcileGitTrackObject) updateChild(found, child *unstructured.Unstruc
 	// HasSupport returns an error if dry run not supported
 	if farosflags.ServerDryRun {
 		if err := r.dryRunVerifier.HasSupport(child.GroupVersionKind()); err == nil {
-			r.log.V(5).Info("Updating child with dry-run support")
+			r.log.V(2).Info("Updating child with dry-run support")
 			return r.applyChildWithDryRun(found, child, false)
 		}
 	}
 	// Dry run not supported so apply without DryRun
-	r.log.V(5).Info("Updating child without dry-run support")
+	r.log.V(2).Info("Updating child without dry-run support")
 	return r.applyChild(found, child, false)
 }
 

--- a/pkg/controller/gittrackobject/handler_test.go
+++ b/pkg/controller/gittrackobject/handler_test.go
@@ -101,9 +101,9 @@ var _ = Describe("Handler Suite", func() {
 				Expect(testutils.SetGitTrackObjectInterfaceSpec(gto, child)).To(Succeed())
 
 				r = r.withValues(
-					"Namespace", gto.GetNamespace(),
-					"ChildName", gto.GetSpec().Name,
-					"ChildKind", gto.GetSpec().Kind,
+					"namespace", gto.GetNamespace(),
+					"child name", gto.GetSpec().Name,
+					"child kind", gto.GetSpec().Kind,
 				)
 
 				// Create and fetch the instance to make sure caches are synced

--- a/pkg/controller/gittrackobject/handler_test.go
+++ b/pkg/controller/gittrackobject/handler_test.go
@@ -247,9 +247,9 @@ var _ = Describe("Handler Suite", func() {
 				Expect(testutils.SetGitTrackObjectInterfaceSpec(gto, child)).To(Succeed())
 
 				r = r.withValues(
-					"Namespace", gto.GetNamespace(),
-					"ChildName", gto.GetSpec().Name,
-					"ChildKind", gto.GetSpec().Kind,
+					"namespace", gto.GetNamespace(),
+					"child name", gto.GetSpec().Name,
+					"child kind", gto.GetSpec().Kind,
 				)
 
 				// Create and fetch the instance to make sure caches are synced

--- a/pkg/controller/gittrackobject/handler_test.go
+++ b/pkg/controller/gittrackobject/handler_test.go
@@ -100,6 +100,12 @@ var _ = Describe("Handler Suite", func() {
 				child = testutils.ExampleDeployment.DeepCopy()
 				Expect(testutils.SetGitTrackObjectInterfaceSpec(gto, child)).To(Succeed())
 
+				r = r.withValues(
+					"Namespace", gto.GetNamespace(),
+					"ChildName", gto.GetSpec().Name,
+					"ChildKind", gto.GetSpec().Kind,
+				)
+
 				// Create and fetch the instance to make sure caches are synced
 				m.Create(gto).Should(Succeed())
 				m.Get(gto, timeout).Should(Succeed())
@@ -239,6 +245,12 @@ var _ = Describe("Handler Suite", func() {
 				gto = testutils.ExampleClusterGitTrackObject.DeepCopy()
 				child = testutils.ExampleClusterRoleBinding.DeepCopy()
 				Expect(testutils.SetGitTrackObjectInterfaceSpec(gto, child)).To(Succeed())
+
+				r = r.withValues(
+					"Namespace", gto.GetNamespace(),
+					"ChildName", gto.GetSpec().Name,
+					"ChildKind", gto.GetSpec().Kind,
+				)
 
 				// Create and fetch the instance to make sure caches are synced
 				m.Create(gto).Should(Succeed())

--- a/pkg/controller/gittrackobject/metrics_test.go
+++ b/pkg/controller/gittrackobject/metrics_test.go
@@ -63,6 +63,12 @@ var _ = Describe("Metrics Suite", func() {
 
 			BeforeEach(func() {
 				gto = testutils.ExampleGitTrackObject.DeepCopy()
+
+				r = r.withValues(
+					"Namespace", gto.GetNamespace(),
+					"ChildName", gto.GetSpec().Name,
+					"ChildKind", gto.GetSpec().Kind,
+				)
 			})
 
 			Context("with inSync true", func() {
@@ -97,6 +103,12 @@ var _ = Describe("Metrics Suite", func() {
 
 			BeforeEach(func() {
 				gto = testutils.ExampleClusterGitTrackObject.DeepCopy()
+
+				r = r.withValues(
+					"Namespace", gto.GetNamespace(),
+					"ChildName", gto.GetSpec().Name,
+					"ChildKind", gto.GetSpec().Kind,
+				)
 			})
 
 			Context("with inSync true", func() {

--- a/pkg/controller/gittrackobject/metrics_test.go
+++ b/pkg/controller/gittrackobject/metrics_test.go
@@ -65,9 +65,9 @@ var _ = Describe("Metrics Suite", func() {
 				gto = testutils.ExampleGitTrackObject.DeepCopy()
 
 				r = r.withValues(
-					"Namespace", gto.GetNamespace(),
-					"ChildName", gto.GetSpec().Name,
-					"ChildKind", gto.GetSpec().Kind,
+					"namespace", gto.GetNamespace(),
+					"child name", gto.GetSpec().Name,
+					"child kind", gto.GetSpec().Kind,
 				)
 			})
 
@@ -105,9 +105,9 @@ var _ = Describe("Metrics Suite", func() {
 				gto = testutils.ExampleClusterGitTrackObject.DeepCopy()
 
 				r = r.withValues(
-					"Namespace", gto.GetNamespace(),
-					"ChildName", gto.GetSpec().Name,
-					"ChildKind", gto.GetSpec().Kind,
+					"namespace", gto.GetNamespace(),
+					"child name", gto.GetSpec().Name,
+					"child kind", gto.GetSpec().Kind,
 				)
 			})
 

--- a/pkg/controller/gittrackobject/status.go
+++ b/pkg/controller/gittrackobject/status.go
@@ -19,7 +19,6 @@ package gittrackobject
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
 
 	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
@@ -83,11 +82,11 @@ func (r *ReconcileGitTrackObject) updateStatus(original farosv1alpha1.GitTrackOb
 	gto := original.DeepCopyInterface()
 	gtoUpdated := updateGitTrackObjectStatus(gto, opts)
 	if gtoUpdated {
-		log.Printf("Updating %s/%s status", gto.GetNamespace(), gto.GetName())
 		err := r.Update(context.TODO(), gto)
 		if err != nil {
 			return fmt.Errorf("unable to update status: %v", err)
 		}
+		r.log.V(2).Info("Parent status Updated")
 	}
 
 	return nil

--- a/pkg/controller/gittrackobject/status.go
+++ b/pkg/controller/gittrackobject/status.go
@@ -86,7 +86,7 @@ func (r *ReconcileGitTrackObject) updateStatus(original farosv1alpha1.GitTrackOb
 		if err != nil {
 			return fmt.Errorf("unable to update status: %v", err)
 		}
-		r.log.V(2).Info("Parent status Updated")
+		r.log.V(1).Info("Parent status Updated")
 	}
 
 	return nil

--- a/pkg/controller/gittrackobject/status.go
+++ b/pkg/controller/gittrackobject/status.go
@@ -86,7 +86,7 @@ func (r *ReconcileGitTrackObject) updateStatus(original farosv1alpha1.GitTrackOb
 		if err != nil {
 			return fmt.Errorf("unable to update status: %v", err)
 		}
-		r.log.V(1).Info("Parent status Updated")
+		r.log.V(1).Info("Parent status updated")
 	}
 
 	return nil

--- a/pkg/controller/gittrackobject/status_test.go
+++ b/pkg/controller/gittrackobject/status_test.go
@@ -92,9 +92,9 @@ var _ = Describe("Status Suite", func() {
 				gto = testutils.ExampleGitTrackObject.DeepCopy()
 
 				r = r.withValues(
-					"Namespace", gto.GetNamespace(),
-					"ChildName", gto.GetSpec().Name,
-					"ChildKind", gto.GetSpec().Kind,
+					"namespace", gto.GetNamespace(),
+					"child name", gto.GetSpec().Name,
+					"child kind", gto.GetSpec().Kind,
 				)
 
 				m.Create(gto).Should(Succeed())
@@ -153,9 +153,9 @@ var _ = Describe("Status Suite", func() {
 				gto = testutils.ExampleClusterGitTrackObject.DeepCopy()
 
 				r = r.withValues(
-					"Namespace", gto.GetNamespace(),
-					"ChildName", gto.GetSpec().Name,
-					"ChildKind", gto.GetSpec().Kind,
+					"namespace", gto.GetNamespace(),
+					"child name", gto.GetSpec().Name,
+					"child kind", gto.GetSpec().Kind,
 				)
 
 				m.Create(gto).Should(Succeed())

--- a/pkg/controller/gittrackobject/status_test.go
+++ b/pkg/controller/gittrackobject/status_test.go
@@ -90,6 +90,13 @@ var _ = Describe("Status Suite", func() {
 
 			BeforeEach(func() {
 				gto = testutils.ExampleGitTrackObject.DeepCopy()
+
+				r = r.withValues(
+					"Namespace", gto.GetNamespace(),
+					"ChildName", gto.GetSpec().Name,
+					"ChildKind", gto.GetSpec().Kind,
+				)
+
 				m.Create(gto).Should(Succeed())
 				m.Get(gto, timeout).Should(Succeed())
 			})
@@ -144,6 +151,13 @@ var _ = Describe("Status Suite", func() {
 
 			BeforeEach(func() {
 				gto = testutils.ExampleClusterGitTrackObject.DeepCopy()
+
+				r = r.withValues(
+					"Namespace", gto.GetNamespace(),
+					"ChildName", gto.GetSpec().Name,
+					"ChildKind", gto.GetSpec().Kind,
+				)
+
 				m.Create(gto).Should(Succeed())
 				m.Get(gto, timeout).Should(Succeed())
 			})

--- a/pkg/controller/gittrackobject/utils/enqueue_owner.go
+++ b/pkg/controller/gittrackobject/utils/enqueue_owner.go
@@ -45,7 +45,7 @@ func (e *EnqueueRequestForOwner) Create(evt event.CreateEvent, q workqueue.RateL
 	_, namespaced, err := utils.GetAPIResource(e.restMapper, evt.Object.GetObjectKind().GroupVersionKind())
 	if err != nil && e.Log != nil {
 		gvk := evt.Object.GetObjectKind().GroupVersionKind()
-		e.Log.Error(err, "unable to get API resource", "Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind)
+		e.Log.Error(err, "unable to get API resource", "group", gvk.Group, "version", gvk.Version, "kind", gvk.Kind)
 	}
 	if namespaced {
 		e.NamespacedEnqueueRequestForOwner.Create(evt, q)
@@ -59,7 +59,7 @@ func (e *EnqueueRequestForOwner) Update(evt event.UpdateEvent, q workqueue.RateL
 	_, namespaced, err := utils.GetAPIResource(e.restMapper, evt.ObjectNew.GetObjectKind().GroupVersionKind())
 	if err != nil && e.Log != nil {
 		gvk := evt.ObjectNew.GetObjectKind().GroupVersionKind()
-		e.Log.Error(err, "unable to get API resource", "Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind)
+		e.Log.Error(err, "unable to get API resource", "group", gvk.Group, "version", gvk.Version, "kind", gvk.Kind)
 	}
 	if namespaced {
 		e.NamespacedEnqueueRequestForOwner.Update(evt, q)
@@ -73,7 +73,7 @@ func (e *EnqueueRequestForOwner) Delete(evt event.DeleteEvent, q workqueue.RateL
 	_, namespaced, err := utils.GetAPIResource(e.restMapper, evt.Object.GetObjectKind().GroupVersionKind())
 	if err != nil && e.Log != nil {
 		gvk := evt.Object.GetObjectKind().GroupVersionKind()
-		e.Log.Error(err, "unable to get API resource", "Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind)
+		e.Log.Error(err, "unable to get API resource", "group", gvk.Group, "version", gvk.Version, "kind", gvk.Kind)
 	}
 	if namespaced {
 		e.NamespacedEnqueueRequestForOwner.Delete(evt, q)
@@ -87,7 +87,7 @@ func (e *EnqueueRequestForOwner) Generic(evt event.GenericEvent, q workqueue.Rat
 	_, namespaced, err := utils.GetAPIResource(e.restMapper, evt.Object.GetObjectKind().GroupVersionKind())
 	if err != nil && e.Log != nil {
 		gvk := evt.Object.GetObjectKind().GroupVersionKind()
-		e.Log.Error(err, "unable to get API resource", "Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind)
+		e.Log.Error(err, "unable to get API resource", "group", gvk.Group, "version", gvk.Version, "kind", gvk.Kind)
 	}
 	if namespaced {
 		e.NamespacedEnqueueRequestForOwner.Generic(evt, q)

--- a/pkg/controller/gittrackobject/utils/enqueue_owner.go
+++ b/pkg/controller/gittrackobject/utils/enqueue_owner.go
@@ -17,8 +17,7 @@ limitations under the License.
 package utils
 
 import (
-	"log"
-
+	"github.com/go-logr/logr"
 	"github.com/pusher/faros/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,14 +36,16 @@ var _ handler.EventHandler = &EnqueueRequestForOwner{}
 type EnqueueRequestForOwner struct {
 	NamespacedEnqueueRequestForOwner    *handler.EnqueueRequestForOwner
 	NonNamespacedEnqueueRequestForOwner *handler.EnqueueRequestForOwner
+	Log                                 logr.Logger
 	restMapper                          meta.RESTMapper
 }
 
 // Create implements EventHandler
 func (e *EnqueueRequestForOwner) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 	_, namespaced, err := utils.GetAPIResource(e.restMapper, evt.Object.GetObjectKind().GroupVersionKind())
-	if err != nil {
-		log.Printf("unable to get API resource: %v", err)
+	if err != nil && e.Log != nil {
+		gvk := evt.Object.GetObjectKind().GroupVersionKind()
+		e.Log.Error(err, "unable to get API resource", "Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind)
 	}
 	if namespaced {
 		e.NamespacedEnqueueRequestForOwner.Create(evt, q)
@@ -56,8 +57,9 @@ func (e *EnqueueRequestForOwner) Create(evt event.CreateEvent, q workqueue.RateL
 // Update implements EventHandler
 func (e *EnqueueRequestForOwner) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	_, namespaced, err := utils.GetAPIResource(e.restMapper, evt.ObjectNew.GetObjectKind().GroupVersionKind())
-	if err != nil {
-		log.Printf("unable to get API resource: %v", err)
+	if err != nil && e.Log != nil {
+		gvk := evt.ObjectNew.GetObjectKind().GroupVersionKind()
+		e.Log.Error(err, "unable to get API resource", "Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind)
 	}
 	if namespaced {
 		e.NamespacedEnqueueRequestForOwner.Update(evt, q)
@@ -69,8 +71,9 @@ func (e *EnqueueRequestForOwner) Update(evt event.UpdateEvent, q workqueue.RateL
 // Delete implements EventHandler
 func (e *EnqueueRequestForOwner) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 	_, namespaced, err := utils.GetAPIResource(e.restMapper, evt.Object.GetObjectKind().GroupVersionKind())
-	if err != nil {
-		log.Printf("unable to get API resource: %v", err)
+	if err != nil && e.Log != nil {
+		gvk := evt.Object.GetObjectKind().GroupVersionKind()
+		e.Log.Error(err, "unable to get API resource", "Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind)
 	}
 	if namespaced {
 		e.NamespacedEnqueueRequestForOwner.Delete(evt, q)
@@ -82,8 +85,9 @@ func (e *EnqueueRequestForOwner) Delete(evt event.DeleteEvent, q workqueue.RateL
 // Generic implements EventHandler
 func (e *EnqueueRequestForOwner) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 	_, namespaced, err := utils.GetAPIResource(e.restMapper, evt.Object.GetObjectKind().GroupVersionKind())
-	if err != nil {
-		log.Printf("unable to get API resource: %v", err)
+	if err != nil && e.Log != nil {
+		gvk := evt.Object.GetObjectKind().GroupVersionKind()
+		e.Log.Error(err, "unable to get API resource", "Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind)
 	}
 	if namespaced {
 		e.NamespacedEnqueueRequestForOwner.Generic(evt, q)

--- a/pkg/controller/gittrackobject/utils/event_handler.go
+++ b/pkg/controller/gittrackobject/utils/event_handler.go
@@ -17,17 +17,19 @@ limitations under the License.
 package utils
 
 import (
-	"log"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	rlogr "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 // EventToChannelHandler send all events onto the EventsChan for consumption
 // and filtering by the controller's Watch function
 type EventToChannelHandler struct {
 	EventsChan chan event.GenericEvent
+	Kind       string
 }
 
 // OnAdd implements the cache.ResoureEventHandler interface
@@ -54,7 +56,8 @@ func (e *EventToChannelHandler) queueEventForObject(obj interface{}) {
 	var u *unstructured.Unstructured
 	var ok bool
 	if u, ok = obj.(*unstructured.Unstructured); !ok {
-		log.Printf("unable to create unstructured object from interface: %+v", obj)
+		log := rlogr.Log.WithName("gittrackobject-controller/event-to-channel-handler")
+		log.Error(fmt.Errorf("unable to create unstructured object from interface"), "Unable to queue event for object", "kind", e.Kind)
 		return
 	}
 

--- a/pkg/controller/gittrackobject/watch.go
+++ b/pkg/controller/gittrackobject/watch.go
@@ -18,7 +18,6 @@ package gittrackobject
 
 import (
 	"fmt"
-	"log"
 
 	gittrackobjectutils "github.com/pusher/faros/pkg/controller/gittrackobject/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -33,12 +32,10 @@ func (r *ReconcileGitTrackObject) watch(obj unstructured.Unstructured) error {
 	}
 
 	// Create new informer
-	log.Printf("Creating new informer for kind %s", obj.GetObjectKind().GroupVersionKind().Kind)
+	r.log.V(3).Info("Creating informer for child kind")
 	informer, err := r.cache.GetInformer(&obj)
 	if err != nil {
-		msg := fmt.Sprintf("error creating informer: %v", err)
-		log.Printf(msg)
-		return fmt.Errorf(msg)
+		return fmt.Errorf("error creating informer: %v", err)
 	}
 
 	// Add event handlers

--- a/pkg/controller/gittrackobject/watch.go
+++ b/pkg/controller/gittrackobject/watch.go
@@ -32,7 +32,7 @@ func (r *ReconcileGitTrackObject) watch(obj unstructured.Unstructured) error {
 	}
 
 	// Create new informer
-	r.log.V(3).Info("Creating informer for child kind")
+	r.log.V(1).Info("Creating informer for child kind")
 	informer, err := r.cache.GetInformer(&obj)
 	if err != nil {
 		return fmt.Errorf("error creating informer: %v", err)

--- a/pkg/controller/gittrackobject/watch.go
+++ b/pkg/controller/gittrackobject/watch.go
@@ -40,6 +40,7 @@ func (r *ReconcileGitTrackObject) watch(obj unstructured.Unstructured) error {
 
 	// Add event handlers
 	informer.AddEventHandler(&gittrackobjectutils.EventToChannelHandler{
+		Kind:       obj.GetKind(),
 		EventsChan: r.eventStream,
 	})
 

--- a/pkg/utils/client/apply.go
+++ b/pkg/utils/client/apply.go
@@ -203,7 +203,7 @@ func (a *Applier) create(ctx context.Context, opts *ApplyOptions, obj runtime.Ob
 		"Name", metadata.GetName(),
 		"Namespace", metadata.GetNamespace(),
 	)
-	log.V(4).Info("creating resource", "dry-run", *opts.ServerDryRun)
+	log.V(2).Info("creating resource", "dry-run", *opts.ServerDryRun)
 
 	err = createApplyAnnotation(obj, unstructured.UnstructuredJSONScheme)
 	if err != nil {
@@ -223,7 +223,6 @@ func (a *Applier) create(ctx context.Context, opts *ApplyOptions, obj runtime.Ob
 
 	createOptions := &metav1.CreateOptions{}
 	if *opts.ServerDryRun {
-		log.V(4).Info("creating with dryRun=all")
 		createOptions.DryRun = []string{metav1.DryRunAll}
 	}
 
@@ -252,7 +251,7 @@ func (a *Applier) update(ctx context.Context, opts *ApplyOptions, current, modif
 		"Name", metadata.GetName(),
 		"Namespace", metadata.GetNamespace(),
 	)
-	log.V(4).Info("updating resource", "dry-run", *opts.ServerDryRun)
+	log.V(2).Info("updating resource", "dry-run", *opts.ServerDryRun)
 
 	modifiedJSON, err := getModifiedConfiguration(modified, true, unstructured.UnstructuredJSONScheme)
 	if err != nil {

--- a/pkg/utils/client/apply.go
+++ b/pkg/utils/client/apply.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/jonboulle/clockwork"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -40,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	rlogr "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 // Options are creation options for a Applier
@@ -69,6 +71,7 @@ type Applier struct {
 	dynamicClient dynamic.Interface
 	config        *rest.Config
 	codecs        serializer.CodecFactory
+	log           logr.Logger
 }
 
 // NewApplier constucts a new Applier client
@@ -114,6 +117,7 @@ func NewApplier(config *rest.Config, options Options) (*Applier, error) {
 		client:        cachingClient,
 		dynamicClient: dynamicClient,
 		config:        config,
+		log:           rlogr.Log.WithName("applier"),
 	}
 
 	return a, nil
@@ -190,7 +194,18 @@ func (a *Applier) Apply(ctx context.Context, opts *ApplyOptions, modified runtim
 }
 
 func (a *Applier) create(ctx context.Context, opts *ApplyOptions, obj runtime.Object) error {
-	err := createApplyAnnotation(obj, unstructured.UnstructuredJSONScheme)
+	metadata, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("unable to read metadata from object: %v", err)
+	}
+	log := a.log.WithValues(
+		"Kind", obj.GetObjectKind().GroupVersionKind().String(),
+		"Name", metadata.GetName(),
+		"Namespace", metadata.GetNamespace(),
+	)
+	log.V(4).Info("creating resource", "dry-run", *opts.ServerDryRun)
+
+	err = createApplyAnnotation(obj, unstructured.UnstructuredJSONScheme)
 	if err != nil {
 		return fmt.Errorf("unable to apply LastAppliedAnnotation to object: %v", err)
 	}
@@ -206,13 +221,9 @@ func (a *Applier) create(ctx context.Context, opts *ApplyOptions, obj runtime.Ob
 		return fmt.Errorf("unable to get REST mapping for GroupVersionKind %s: %v", gvk.String(), err)
 	}
 
-	metadata, err := meta.Accessor(obj)
-	if err != nil {
-		return fmt.Errorf("unable to get metadata: %v", err)
-	}
-
 	createOptions := &metav1.CreateOptions{}
 	if *opts.ServerDryRun {
+		log.V(4).Info("creating with dryRun=all")
 		createOptions.DryRun = []string{metav1.DryRunAll}
 	}
 
@@ -231,14 +242,21 @@ func (a *Applier) create(ctx context.Context, opts *ApplyOptions, obj runtime.Ob
 }
 
 func (a *Applier) update(ctx context.Context, opts *ApplyOptions, current, modified runtime.Object) error {
-	modifiedJSON, err := getModifiedConfiguration(modified, true, unstructured.UnstructuredJSONScheme)
-	if err != nil {
-		return fmt.Errorf("unable to get modified configuration: %v", err)
-	}
-
 	metadata, err := meta.Accessor(modified)
 	if err != nil {
 		return fmt.Errorf("unable to get object metadata: %v", err)
+	}
+
+	log := a.log.WithValues(
+		"Kind", modified.GetObjectKind().GroupVersionKind().String(),
+		"Name", metadata.GetName(),
+		"Namespace", metadata.GetNamespace(),
+	)
+	log.V(4).Info("updating resource", "dry-run", *opts.ServerDryRun)
+
+	modifiedJSON, err := getModifiedConfiguration(modified, true, unstructured.UnstructuredJSONScheme)
+	if err != nil {
+		return fmt.Errorf("unable to get modified configuration: %v", err)
 	}
 
 	patcher, err := a.newPatcher(opts, modified)

--- a/pkg/utils/client/apply.go
+++ b/pkg/utils/client/apply.go
@@ -199,9 +199,9 @@ func (a *Applier) create(ctx context.Context, opts *ApplyOptions, obj runtime.Ob
 		return fmt.Errorf("unable to read metadata from object: %v", err)
 	}
 	log := a.log.WithValues(
-		"Kind", obj.GetObjectKind().GroupVersionKind().String(),
-		"Name", metadata.GetName(),
-		"Namespace", metadata.GetNamespace(),
+		"kind", obj.GetObjectKind().GroupVersionKind().String(),
+		"name", metadata.GetName(),
+		"namespace", metadata.GetNamespace(),
 	)
 	log.V(2).Info("creating resource", "dry-run", *opts.ServerDryRun)
 
@@ -247,9 +247,9 @@ func (a *Applier) update(ctx context.Context, opts *ApplyOptions, current, modif
 	}
 
 	log := a.log.WithValues(
-		"Kind", modified.GetObjectKind().GroupVersionKind().String(),
-		"Name", metadata.GetName(),
-		"Namespace", metadata.GetNamespace(),
+		"kind", modified.GetObjectKind().GroupVersionKind().String(),
+		"name", metadata.GetName(),
+		"namespace", metadata.GetNamespace(),
 	)
 	log.V(2).Info("updating resource", "dry-run", *opts.ServerDryRun)
 

--- a/pkg/utils/client/client_suite_test.go
+++ b/pkg/utils/client/client_suite_test.go
@@ -23,11 +23,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-logr/glogr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pusher/faros/test/reporters"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -47,7 +47,7 @@ var t *envtest.Environment
 var _ = BeforeSuite(func() {
 	t = &envtest.Environment{}
 
-	logf.SetLogger(glogr.New())
+	logf.SetLogger(klogr.New())
 
 	var err error
 	if cfg, err = t.Start(); err != nil {


### PR DESCRIPTION
This PR intends to improve debug logging throughout the Faros codebase.

It introduces the `logr` framework and `klog` logging to allow more structured and levelled logging throughout the codebase.

I've also changed the logging so that it _should_ log by default to `stdout` and only log to `stderr` for actual errors or if `--logtostderr=true` is passed CC @sebastianroesch 

I've built an image which I'm going to test internally `quay.io/pusher/faros:pull-114`

This is pretty much exclusively conversion at the moment and doesn't actually add that much in the way of logging, but I think we need to work out what extra logs we want

Fixes #122 (?)