### PR TITLE
Use dynamicCodec for decoding errors

### DIFF
--- a/pkg/utils/client/apply.go
+++ b/pkg/utils/client/apply.go
@@ -305,7 +305,8 @@ func (a *Applier) configFor(gv schema.GroupVersion) (*rest.Config, error) {
 		config.APIPath = "apis/"
 	}
 
-	config.NegotiatedSerializer = serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{Serializer: unstructured.UnstructuredJSONScheme})
+	contentConfig := resource.UnstructuredPlusDefaultContentConfig()
+	config.NegotiatedSerializer = contentConfig.NegotiatedSerializer
 	return config, nil
 }
 


### PR DESCRIPTION
This fix enables proper decoding of Kubernetes API errors and converts useless messages such as `error creating object: the server rejected our request for an unknown reason (post deployments.apps)` into proper error messages like`error creating object: dryRun is not supported yet`

CC @samuelyallop-pusher 