### PR TITLE
Allow disabling dry-run tests

### DIFF
--- a/pkg/utils/client/apply_test.go
+++ b/pkg/utils/client/apply_test.go
@@ -109,6 +109,9 @@ var _ = Describe("Applier Suite", func() {
 
 		Context("with ServerDryRun true", func() {
 			BeforeEach(func() {
+				if skipDryRun {
+					Skip("dry run tests are skipped")
+				}
 				serverDryRun := true
 				o.ServerDryRun = &serverDryRun
 				Expect(a.Apply(context.TODO(), o, deployment)).NotTo(HaveOccurred())
@@ -167,6 +170,9 @@ var _ = Describe("Applier Suite", func() {
 
 			Context("with ServerDryRun true", func() {
 				BeforeEach(func() {
+					if skipDryRun {
+						Skip("dry run tests are skipped")
+					}
 					serverDryRun := true
 					o.ServerDryRun = &serverDryRun
 					Expect(a.Apply(context.TODO(), o, deployment)).NotTo(HaveOccurred())

--- a/pkg/utils/client/client_suite_test.go
+++ b/pkg/utils/client/client_suite_test.go
@@ -18,6 +18,8 @@ package client
 
 import (
 	"log"
+	"os"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -33,6 +35,7 @@ import (
 )
 
 var cfg *rest.Config
+var skipDryRun bool
 
 func TestMain(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -49,6 +52,10 @@ var _ = BeforeSuite(func() {
 	var err error
 	if cfg, err = t.Start(); err != nil {
 		log.Fatal(err)
+	}
+	if skipDryRunEnv := os.Getenv("SKIP_DRY_RUN_TESTS"); skipDryRunEnv != "" {
+		skipDryRun, err = strconv.ParseBool(skipDryRunEnv)
+		Expect(err).NotTo(HaveOccurred())
 	}
 })
 


### PR DESCRIPTION
Allows us to skip testing dry run against versions of K8s that do not support it