### PR TITLE
Fix linting configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,18 +53,17 @@ vet:
 lint:
 	@ echo "\033[36mLinting code\033[0m"
 	$(LINTER) run --disable-all \
-          --enable=vet \
-          --enable=vetshadow \
-          --enable=golint \
-          --enable=ineffassign \
-          --enable=goconst \
-          --enable=deadcode \
-          --enable=gofmt \
-          --enable=goimports \
-          --skip-dirs=pkg/client/ \
-          --deadline=120s \
-          --verbose \
-          --tests ./...
+                --exclude-use-default=false \
+                --enable=govet \
+                --enable=ineffassign \
+                --enable=deadcode \
+                --enable=golint \
+                --enable=goconst \
+                --enable=gofmt \
+                --enable=goimports \
+                --skip-dirs=pkg/client/ \
+                --deadline=120s \
+                --tests ./...
 	@ echo
 
 # Run tests

--- a/pkg/controller/gittrack/git_creds.go
+++ b/pkg/controller/gittrack/git_creds.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gittrack
 
 import (

--- a/pkg/utils/client/patcher.go
+++ b/pkg/utils/client/patcher.go
@@ -128,7 +128,7 @@ func (p *Patcher) patchSimple(obj runtime.Object, modified []byte, source, names
 		}
 	case err != nil:
 		return nil, nil, addSourceToErr(fmt.Sprintf("getting instance of versioned object for %v:", p.Mapping.GroupVersionKind), source, err)
-	case err == nil:
+	default:
 		// Compute a three way strategic merge patch to send to server.
 		patchType = types.StrategicMergePatchType
 


### PR DESCRIPTION
This removes the `--verbose` flag, fixes a couple of misnamed linters and fixes the remaining linting issues on the repository