### PR TITLE
Make `make run` run again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ release: test docker-build docker-tag docker-push
 # Run against the configured Kubernetes cluster in ~/.kube/config
 .PHONY: run
 run: generate fmt vet
-	$(GO) run ./cmd/manager/main.go
+	$(GO) run ./cmd/manager
 
 # Install CRDs into a cluster
 .PHONY: install


### PR DESCRIPTION
Embarrassingly simple fix for #112, which took way too long to figure out :see_no_evil:

Relevant part from `go help run`:

```bash
$ go help run
usage: go run [build flags] [-exec xprog] package [arguments...]

Run compiles and runs the named main Go package.
Typically the package is specified as a list of .go source files,
but it may also be an import path, file system path, or pattern
matching a single known package, as in 'go run .' or 'go run my/cmd'.
```