### PR TITLE
Add `.dockerignore` to speed up Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+vendor/
+release/
+.git/
+faros-gittrack-controller


### PR DESCRIPTION
Mainly for local development as the excluded directories can become quite large, and provide zero benefit.

```bash
# before
$ docker build -t quay.io/pusher/faros:latest .
Sending build context to Docker daemon  878.2MB
# after
$ docker build -t quay.io/pusher/faros:latest .
Sending build context to Docker daemon  685.1kB
```