### PR TITLE
Update `.gitignore` to reflect current state of affairs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-bin
-vendor
-cover.out
+vendor/
+release/
 .env
-release
+cover.out
+faros-gittrack-controller


### PR DESCRIPTION
We don't build binaries to `bin/` anymore but rather as `faros-gittrack-controller` (into the root of the project) or into `release/`.

Sorry for the messy diff, but my CDO wanted it differently :see_no_evil: