### PR TITLE
Update Dockerfile to match builds produced by `make release`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM golang:1.10.3 as builder
+FROM golang:1.12 as builder
+
+ARG VERSION=undefined
 
 # Install Dep
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
@@ -16,11 +18,11 @@ COPY pkg/    pkg/
 COPY cmd/    cmd/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/pusher/faros/cmd/manager
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o faros-gittrack-controller -ldflags="-X main.VERSION=${VERSION}" github.com/pusher/faros/cmd/manager
 
 # Copy the controller-manager into a thin image
-FROM alpine:3.8
+FROM alpine:3.9
 RUN apk --no-cache add ca-certificates
 WORKDIR /bin
-COPY --from=builder /go/src/github.com/pusher/faros/manager .
-ENTRYPOINT ["/bin/manager"]
+COPY --from=builder /go/src/github.com/pusher/faros/faros-gittrack-controller .
+ENTRYPOINT ["/bin/faros-gittrack-controller"]

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ manifests: vendor
 # Build the docker image
 .PHONY: docker-build
 docker-build:
-	docker build . -t ${IMG}:${VERSION}
+	docker build --build-arg VERSION=${VERSION} -t ${IMG}:${VERSION} .
 	@echo "\033[36mBuilt $(IMG):$(VERSION)\033[0m"
 
 TAGS ?= latest


### PR DESCRIPTION
What it says on the tin. Note that this changes the entrypoint of the Docker image, so we'll probably want to mention that in the CHANGELOG as it is somewhat of a breaking change.