### PR TITLE
clarify faros YAML

### DIFF
--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: controller-manager
+  name: faros
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,39 +5,24 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: system
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: controller-manager-service
-  namespace: system
-  labels:
-    control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-spec:
-  selector:
-    control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-  ports:
-  - port: 443
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: controller-manager
+  name: faros
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: faros
     controller-tools.k8s.io: "1.0"
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: faros
       controller-tools.k8s.io: "1.0"
-  serviceName: controller-manager-service
+  serviceName: faros
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: faros
         controller-tools.k8s.io: "1.0"
     spec:
       containers:


### PR DESCRIPTION
In looking at the example deployment configuration, it's not clear that
"controller-manager" means "faros". This change renames the deployments
to be clearer.

This also removes the unnecessary Service definition, as nothing in
Faros listens on port 443.