### PR TITLE
option to ignore cluster-scoped resources

### DIFF
--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -28,6 +28,7 @@ import (
 	gittrackobjectutils "github.com/pusher/faros/pkg/controller/gittrackobject/utils"
 
 	"github.com/go-logr/logr"
+	farosflags "github.com/pusher/faros/pkg/flags"
 	"github.com/pusher/faros/pkg/utils"
 	farosclient "github.com/pusher/faros/pkg/utils/client"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -102,14 +103,16 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for changes to ClusterGitTrackObject
-	err = c.Watch(
-		&source.Kind{Type: &farosv1alpha1.ClusterGitTrackObject{}},
-		&handler.EnqueueRequestForObject{},
-		utils.NewOwnerInNamespacePredicate(mgr.GetClient()),
-	)
-	if err != nil {
-		return err
+	if !farosflags.NamespacedOnly {
+		// Watch for changes to ClusterGitTrackObject
+		err = c.Watch(
+			&source.Kind{Type: &farosv1alpha1.ClusterGitTrackObject{}},
+			&handler.EnqueueRequestForObject{},
+			utils.NewOwnerInNamespacePredicate(mgr.GetClient()),
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Watch for events on the reconciler's eventStream channel

--- a/pkg/flags/flagset.go
+++ b/pkg/flags/flagset.go
@@ -31,6 +31,9 @@ var (
 	// Namespace is the namespace for the controller to be restricted to
 	Namespace string
 
+	// NamespacedOnly disables management of cluster-level resources
+	NamespacedOnly bool
+
 	// ignoredResources is a list of Kubernets kinds to ignore when reconciling
 	ignoredResources []string
 
@@ -41,6 +44,7 @@ var (
 func init() {
 	FlagSet = flag.NewFlagSet("faros", flag.PanicOnError)
 	FlagSet.StringVar(&Namespace, "namespace", "", "Only manage GitTrack resources in given namespace")
+	FlagSet.BoolVar(&NamespacedOnly, "namespaced-only", false, "Only manage namespace-scoped resources")
 	FlagSet.StringSliceVar(&ignoredResources, "ignore-resource", []string{}, "Ignore resources of these kinds found in repositories, specified in <resource>.<group>/<version> format eg jobs.batch/v1")
 	FlagSet.BoolVar(&ServerDryRun, "server-dry-run", true, "Enable/Disable server side dry run before updating resources")
 }


### PR DESCRIPTION
When running an namespace-scoped instance of Faros in a shared cluster,
listing and modifying cluster-scoped resources may not be allowed. As
Faros begins by listing cluster-scoped resources, this prevents Faros
from operating entirely.

This changelist adds a new flag to the controller `--namespaced-only`
which modifies the behavior of Faros:

1. Faros no longer lists ClusterGitTrackObjects at controller startup.
   Any previously created ClusterGitTrackObjects are abandoned and must
   be cleaned up by the operator.
2. Faros no longer manages any cluster-scoped resources it finds in
   a Git repository, instead adding them to the ignored objects list.

Fixes: #138