### PR TITLE
Feedback: Added resource finalizers

### DIFF
--- a/pkg/controller/gittrackobject/handler.go
+++ b/pkg/controller/gittrackobject/handler.go
@@ -41,6 +41,12 @@ type handlerResult struct {
 	inSyncReason gittrackobjectutils.ConditionReason
 }
 
+// DeletionRequestedAnnotation is the key of the annotation that makes a GTO as requested for deletion.
+const DeletionRequestedAnnotation = "faros.pusher.com/deletion-requested"
+
+// ResourceFinalizer is the name of the Faros finalizer that protects resources from accidental GC deletion.
+const ResourceFinalizer = "faros.pusher.com/deletion-protection"
+
 // handleGitTrackObject handles the management of the child of the GitTrackObjectInterface
 // and returns a handlerResult which contains information for updating the
 // (Cluster)GitTrackObject's status and metrics
@@ -97,6 +103,25 @@ func (r *ReconcileGitTrackObject) handleGitTrackObject(gto farosv1alpha1.GitTrac
 		return handlerResult{
 			inSyncReason: gittrackobjectutils.ErrorGettingChild,
 			inSyncError:  fmt.Errorf("unable to get child %s %s: %v", gto.GetSpec().Kind, gto.GetSpec().Name, err),
+		}
+	}
+
+	// If marked for deletion, remove Finalizer on child and delete GTO.
+	if gto.GetAnnotations()[DeletionRequestedAnnotation] == "true" {
+		finalizers := found.GetFinalizers()
+		var newFinalizers []string
+		for _, finalizer := range finalizers {
+			if finalizer != ResourceFinalizer {
+				newFinalizers = append(newFinalizers, finalizer)
+			}
+		}
+		found.SetFinalizers(newFinalizers)
+		r.Delete(context.TODO(), gto)
+	} else {
+		finalizers := child.GetFinalizers()
+		if !contains(finalizers, ResourceFinalizer) {
+			finalizers = append(finalizers, ResourceFinalizer)
+			child.SetFinalizers(finalizers)
 		}
 	}
 
@@ -282,4 +307,14 @@ func (r *ReconcileGitTrackObject) sendEvent(gto farosv1alpha1.GitTrackObjectInte
 	}
 
 	r.recorder.Eventf(instance, eventType, reason, messageFmt, args...)
+}
+
+// contains check if the specified string array contains a string.
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }

--- a/test/utils/delete.go
+++ b/test/utils/delete.go
@@ -78,6 +78,9 @@ func deleteObj(c client.Client, timeout time.Duration, obj runtime.Object) error
 			return fmt.Errorf("Object has not been deleted")
 		}
 		if len(metaAccessor.GetFinalizers()) > 0 {
+			// Remove existing Finalizers so that delete succeeds on next attempt.
+			metaAccessor.SetFinalizers([]string{})
+			c.Update(context.TODO(), obj)
 			return fmt.Errorf("Object has remaining Finalizers: %v", metaAccessor.GetFinalizers())
 		}
 		// If the object has deletion timestamp and no finalizers,


### PR DESCRIPTION
@JoelSpeed  I would like your feedback on this:

To prevent accidental deletion of resources due to etcd issues and k8s garbage collection, as discussed in #101, I added finalizers to the child resources. This is not the full implementation as discussed, and this behavior is currently not configurable. I would like your feedback on whether this is a good way forward.

We have tested this in different scenarios, most specifically in the etcd leader loss that lead to an outage as described in #143.

Since we still have to delete resources when removed from the GitOps repo, Faros also needs to ability to remove finalizers. But as the `GitTrack` controller, which knows about the leftover resources, does not know the child resources, it cannot remove the finalizers. Therefore, I moved deleting the `GitTrackObject` into the `GitTrackObject` controller so that it can remove the finalizer before being deleted. The `GitTrackObject` is only marked for deletion via an annotation.

I hope this makes sense. Thanks!