### PR TITLE
Update `git-store` and add `--fetch-timeout` flag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -668,12 +668,12 @@
   revision = "418d78d0b9a7b7de3a6bbc8a23def624cc977bb2"
 
 [[projects]]
-  digest = "1:dc16a6f5bdd6af17ace824614da4838c43765bfa7fe1602be9c57655cd2fe0db"
+  digest = "1:086640ee59876950602f4087bfdc5f3d2848833328c31cf894081eefbd0f0a59"
   name = "github.com/pusher/git-store"
   packages = ["."]
   pruneopts = "T"
-  revision = "3cb07ab547c04aee81bc79acd85de16af9709c62"
-  version = "v0.5.0"
+  revision = "92d78f03e11486978999b034c177aa844e7c6041"
+  version = "v0.6.0"
 
 [[projects]]
   digest = "1:40e527269f1feb16b3069bfe80ff05a462d190eacfe07eb0a59fa25c381db7af"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@ required = [
 
 [[constraint]]
 name="github.com/pusher/git-store"
-version="v0.5.0"
+version="v0.6.0"
 
 [[override]]
 name="gopkg.in/src-d/go-git.v4"

--- a/pkg/flags/flagset.go
+++ b/pkg/flags/flagset.go
@@ -19,6 +19,7 @@ package flags
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -36,6 +37,9 @@ var (
 
 	// ServerDryRun whether to enable Server side dry run or not
 	ServerDryRun bool
+
+	// FetchTimeout in seconds for fetching changes from repositories
+	FetchTimeout time.Duration
 )
 
 func init() {
@@ -43,6 +47,7 @@ func init() {
 	FlagSet.StringVar(&Namespace, "namespace", "", "Only manage GitTrack resources in given namespace")
 	FlagSet.StringSliceVar(&ignoredResources, "ignore-resource", []string{}, "Ignore resources of these kinds found in repositories, specified in <resource>.<group>/<version> format eg jobs.batch/v1")
 	FlagSet.BoolVar(&ServerDryRun, "server-dry-run", true, "Enable/Disable server side dry run before updating resources")
+	FlagSet.DurationVar(&FetchTimeout, "fetch-timeout", 30*time.Second, "Timeout in seconds for fetching changes from repositories")
 }
 
 // ParseIgnoredResources attempts to parse the ignore-resource flag value and


### PR DESCRIPTION
This updates the `git-store` dependency to the newly released `v0.6.0` which brings with it great promise of being able to add timeouts to methods that make network calls, and also a reduction in CPU usage by lazily loading file logs on demand rather than when getting all of the files in a repository, see #123.

A new flag, `--fetch-timeout`, has been added (with a default value of 30 seconds), as we've seen Faros sometimes get stuck (no log output whatsoever) and it might be the case that network calls hang indefinitely. Although we've seen the work queue depth decrease, but no new changes being applied. So it might be that adding these timeouts yield nothing, but regardless having timeouts for network calls is a preferable thing to have.