### PR TITLE
Log the Git SHA on each reconcile

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -644,12 +644,12 @@
   revision = "418d78d0b9a7b7de3a6bbc8a23def624cc977bb2"
 
 [[projects]]
-  digest = "1:086640ee59876950602f4087bfdc5f3d2848833328c31cf894081eefbd0f0a59"
+  branch = "repo-head-commit"
+  digest = "1:4296bfe3bb3395d1ea9065b1c8d1b15c0491967de3700e6de4a4b6c66ea52948"
   name = "github.com/pusher/git-store"
   packages = ["."]
   pruneopts = "T"
-  revision = "92d78f03e11486978999b034c177aa844e7c6041"
-  version = "v0.6.0"
+  revision = "99930cf477bd162086fd0758ce57898abc42889d"
 
 [[projects]]
   digest = "1:40e527269f1feb16b3069bfe80ff05a462d190eacfe07eb0a59fa25c381db7af"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -645,11 +645,11 @@
 
 [[projects]]
   branch = "repo-head-commit"
-  digest = "1:4296bfe3bb3395d1ea9065b1c8d1b15c0491967de3700e6de4a4b6c66ea52948"
+  digest = "1:aed46fc29b7a6e86697657ebf2696f131d852549fb7267b24560f260b569cba4"
   name = "github.com/pusher/git-store"
   packages = ["."]
   pruneopts = "T"
-  revision = "99930cf477bd162086fd0758ce57898abc42889d"
+  revision = "e0cece5b5e1ee78de53fc1853fd85370bcf85552"
 
 [[projects]]
   digest = "1:40e527269f1feb16b3069bfe80ff05a462d190eacfe07eb0a59fa25c381db7af"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@ required = [
 
 [[constraint]]
 name="github.com/pusher/git-store"
-version="v0.6.0"
+branch="repo-head-commit"
 
 [[override]]
 name="gopkg.in/src-d/go-git.v4"

--- a/pkg/controller/gittrack/gittrack_controller.go
+++ b/pkg/controller/gittrack/gittrack_controller.go
@@ -146,7 +146,7 @@ func (r *ReconcileGitTrack) withValues(keysAndValues ...interface{}) *ReconcileG
 
 // checkoutRepo checks out the repository at reference and returns a pointer to said repository
 func (r *ReconcileGitTrack) checkoutRepo(url string, ref string, gitCreds *gitCredentials) (*gitstore.Repo, error) {
-	r.log.V(1).Info("Getting repository", "url", url)
+	r.log.V(0).Info("Getting repository", "url", url)
 	repoRef, err := createRepoRefFromCreds(url, gitCreds)
 	if err != nil {
 		return &gitstore.Repo{}, err
@@ -167,7 +167,7 @@ func (r *ReconcileGitTrack) checkoutRepo(url string, ref string, gitCreds *gitCr
 		return repo, fmt.Errorf("timed out getting repository '%s'", url)
 	}
 
-	r.log.V(1).Info("Checking out reference", "reference", ref)
+	r.log.V(0).Info("Checking out reference", "reference", ref)
 	ctx, cancel := context.WithTimeout(context.Background(), farosflags.FetchTimeout)
 	defer cancel()
 	err = repo.CheckoutContext(ctx, ref)
@@ -178,7 +178,7 @@ func (r *ReconcileGitTrack) checkoutRepo(url string, ref string, gitCreds *gitCr
 	if err != nil {
 		return &gitstore.Repo{}, fmt.Errorf("failed to get commit SHA '%s': %v", ref, err)
 	}
-	r.log.V(1).Info("Checked out reference at SHA", "reference", ref, "SHA", commit.Hash.String())
+	r.log.V(0).Info("Checked out reference at SHA", "reference", ref, "SHA", commit.Hash.String())
 
 	lastUpdated, err := repo.LastUpdated()
 	if err != nil {
@@ -539,7 +539,7 @@ func (r *ReconcileGitTrack) Reconcile(request reconcile.Request) (reconcile.Resu
 		"namespace", instance.GetNamespace(),
 		"name", instance.GetName(),
 	)
-	reconciler.log.V(1).Info("Reconcile started")
+	reconciler.log.V(0).Info("Reconcile started")
 
 	sOpts := newStatusOpts()
 	mOpts := newMetricOpts(sOpts)
@@ -549,7 +549,7 @@ func (r *ReconcileGitTrack) Reconcile(request reconcile.Request) (reconcile.Resu
 		err := reconciler.updateStatus(instance, sOpts)
 		mErr := reconciler.updateMetrics(instance, mOpts)
 
-		reconciler.log.V(1).Info("Reconcile finished")
+		reconciler.log.V(0).Info("Reconcile finished")
 		// Print out any errors that may have occurred
 		for _, e := range []error{
 			err,

--- a/pkg/controller/gittrack/gittrack_controller.go
+++ b/pkg/controller/gittrack/gittrack_controller.go
@@ -174,6 +174,11 @@ func (r *ReconcileGitTrack) checkoutRepo(url string, ref string, gitCreds *gitCr
 	if err != nil {
 		return &gitstore.Repo{}, fmt.Errorf("failed to checkout '%s': %v", ref, err)
 	}
+	commit, err := repo.HeadCommit()
+	if err != nil {
+		return &gitstore.Repo{}, fmt.Errorf("failed to get commit SHA '%s': %v", ref, err)
+	}
+	r.log.V(1).Info("Checked out reference at SHA", "reference", ref, "SHA", commit.Hash.String())
 
 	lastUpdated, err := repo.LastUpdated()
 	if err != nil {

--- a/pkg/utils/client/apply.go
+++ b/pkg/utils/client/apply.go
@@ -264,8 +264,10 @@ func (a *Applier) update(ctx context.Context, opts *ApplyOptions, current, modif
 	}
 	source := metadata.GetSelfLink() // This is optional and would normally be the file path
 	patchBytes, patchedObj, err := patcher.Patch(current, modifiedJSON, source, metadata.GetNamespace(), metadata.GetName(), nil)
-	if patchString := string(patchBytes); patchString != "{}" {
-		log.V(2).Info("applied patch", "patch", patchString)
+	if !*opts.ServerDryRun {
+		if patchString := string(patchBytes); patchString != "{}" {
+			log.V(2).Info("applied patch", "patch", patchString)
+		}
 	}
 	if err != nil {
 		return fmt.Errorf("unable to patch object: %v", err)


### PR DESCRIPTION
This is to further debug the issue we've been seeing where Faros doesn't apply even after new commits have been pushed. Seems as if it doesn't get stuck fetching changes from the remote repositories after all.