### PR TITLE
Add Repository Path flag to allow repositories to be cloned to the filesystem

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -644,12 +644,12 @@
   revision = "418d78d0b9a7b7de3a6bbc8a23def624cc977bb2"
 
 [[projects]]
-  digest = "1:086640ee59876950602f4087bfdc5f3d2848833328c31cf894081eefbd0f0a59"
+  digest = "1:3a529c8a032e190b097ee8030693e5afeb72a9647392cee336ccb8a519de65f7"
   name = "github.com/pusher/git-store"
   packages = ["."]
   pruneopts = "T"
-  revision = "92d78f03e11486978999b034c177aa844e7c6041"
-  version = "v0.6.0"
+  revision = "095f4308acf8795a53aa38195f2877b7b13b1518"
+  version = "v0.7.1"
 
 [[projects]]
   digest = "1:40e527269f1feb16b3069bfe80ff05a462d190eacfe07eb0a59fa25c381db7af"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@ required = [
 
 [[constraint]]
 name="github.com/pusher/git-store"
-version="v0.6.0"
+version="0.7.1"
 
 [[override]]
 name="gopkg.in/src-d/go-git.v4"

--- a/pkg/controller/gittrack/gittrack_controller.go
+++ b/pkg/controller/gittrack/gittrack_controller.go
@@ -78,7 +78,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileGitTrack{
 		Client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
-		store:           gitstore.NewRepoStore(),
+		store:           gitstore.NewRepoStore(farosflags.RepositoryDir),
 		restMapper:      restMapper,
 		recorder:        mgr.GetEventRecorderFor("gittrack-controller"),
 		ignoredGVRs:     gvrs,

--- a/pkg/flags/flagset.go
+++ b/pkg/flags/flagset.go
@@ -40,6 +40,11 @@ var (
 
 	// FetchTimeout in seconds for fetching changes from repositories
 	FetchTimeout time.Duration
+
+	// RepositoryDir is the folder on the local filesystem in which Faros should
+	// check out repositories. If left empty, Faros will check out repositories
+	// in memory
+	RepositoryDir string
 )
 
 func init() {
@@ -48,6 +53,7 @@ func init() {
 	FlagSet.StringSliceVar(&ignoredResources, "ignore-resource", []string{}, "Ignore resources of these kinds found in repositories, specified in <resource>.<group>/<version> format eg jobs.batch/v1")
 	FlagSet.BoolVar(&ServerDryRun, "server-dry-run", true, "Enable/Disable server side dry run before updating resources")
 	FlagSet.DurationVar(&FetchTimeout, "fetch-timeout", 30*time.Second, "Timeout in seconds for fetching changes from repositories")
+	FlagSet.StringVar(&RepositoryDir, "repository-dir", "", "Directory in which to clone repositories. Defaults to cloning in memory if unset.")
 }
 
 // ParseIgnoredResources attempts to parse the ignore-resource flag value and


### PR DESCRIPTION
This PR adds the ability for Faros to clone repositories onto the filesystem rather than in memory.

We have noticed some issues with Faros' interactions with Git and this may help resolve that issue and/or help to debug it

This PR also bumps git-store to v0.7.0 which includes fixes for non-`master` default branches not being updated over time