### PR TITLE
Add GitTrack Handler and tests

### DIFF
--- a/pkg/controller/gittrack/handler.go
+++ b/pkg/controller/gittrack/handler.go
@@ -17,10 +17,14 @@ limitations under the License.
 package gittrack
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
 	gittrackutils "github.com/pusher/faros/pkg/controller/gittrack/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // handlerResult is the single return object from handleGitTrack
@@ -44,5 +48,87 @@ type handlerResult struct {
 }
 
 func (r *ReconcileGitTrack) handleGitTrack(gt farosv1alpha1.GitTrackInterface) handlerResult {
-	return handlerResult{}
+	var result handlerResult
+
+	// Get a map of the files that are in the Spec
+	files, err := r.getFiles(gt)
+	if err != nil {
+		result.gitError = err
+		result.gitReason = gittrackutils.ErrorFetchingFiles
+		return result
+	}
+	// Git successful, set condition
+	result.gitReason = gittrackutils.GitFetchSuccess
+	r.recorder.Eventf(gt, corev1.EventTypeNormal, "CheckoutSuccessful", "Successfully checked out '%s' at '%s'", gt.GetSpec().Repository, gt.GetSpec().Reference)
+
+	// Attempt to parse k8s objects from files
+	objects, fileErrors := objectsFrom(files)
+	result.ignoredFiles = fileErrors
+	result.ignored += int64(len(fileErrors))
+	if len(fileErrors) > 0 {
+		var errs []string
+		for file, reason := range fileErrors {
+			errs = append(errs, fmt.Sprintf("%s: %s", file, reason))
+		}
+		result.parseError = fmt.Errorf(strings.Join(errs, ",\n"))
+		result.parseReason = gittrackutils.ErrorParsingFiles
+	} else {
+		result.parseReason = gittrackutils.FileParseSuccess
+	}
+
+	// Update status with the number of objects discovered
+	result.discovered = int64(len(objects))
+
+	// Get a list of the GitTrackObjects that currently exist, by name
+	objectsByName, err := r.listObjectsByName(gt)
+	if err != nil {
+		return result
+	}
+	// Process the objects and feed back the results
+	resultsChan := make(chan objectResult, len(objects))
+	for _, obj := range objects {
+		go func(obj *unstructured.Unstructured) {
+			resultsChan <- r.handleObject(obj, gt)
+		}(obj)
+	}
+
+	handlerErrors := []string{}
+	// Iterate through results and update status accordingly
+	for range objects {
+		res := <-resultsChan
+		if res.Ignored {
+			result.ignoredFiles[res.NamespacedName] = res.Reason
+			result.ignored++
+		} else {
+			result.applied++
+		}
+		result.timeToDeploy = append(result.timeToDeploy, res.TimeToDeploy)
+		if res.InSync {
+			result.inSync++
+		}
+		delete(objectsByName, res.NamespacedName)
+		if res.Error != nil {
+			handlerErrors = append(handlerErrors, res.Error.Error())
+		}
+	}
+
+	// If there were errors updating the child objects, set the ChildrenUpToDate
+	// condition appropriately
+	if len(handlerErrors) > 0 {
+		result.upToDateError = fmt.Errorf(strings.Join(handlerErrors, ",\n"))
+		result.upToDateReason = gittrackutils.ErrorUpdatingChildren
+	} else {
+		result.upToDateReason = gittrackutils.ChildrenUpdateSuccess
+	}
+
+	// Cleanup potentially leftover resources
+	if err = r.deleteResources(objectsByName); err != nil {
+		result.gcError = err
+		result.gcReason = gittrackutils.ErrorDeletingChildren
+		r.recorder.Eventf(gt, corev1.EventTypeWarning, "CleanupFailed", "Failed to clean-up leftover resources")
+		return result
+	}
+	result.gcReason = gittrackutils.GCSuccess
+
+	return result
 }

--- a/pkg/controller/gittrack/handler.go
+++ b/pkg/controller/gittrack/handler.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gittrack
+
+import (
+	"time"
+
+	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
+	gittrackutils "github.com/pusher/faros/pkg/controller/gittrack/utils"
+)
+
+// handlerResult is the single return object from handleGitTrack
+// It contains all information required to update the status and metrics of
+// the (Cluster)GitTrack passed to it
+type handlerResult struct {
+	applied        int64
+	discovered     int64
+	ignored        int64
+	inSync         int64
+	parseError     error
+	parseReason    gittrackutils.ConditionReason
+	gitError       error
+	gitReason      gittrackutils.ConditionReason
+	gcError        error
+	gcReason       gittrackutils.ConditionReason
+	upToDateError  error
+	upToDateReason gittrackutils.ConditionReason
+	ignoredFiles   map[string]string
+	timeToDeploy   []time.Duration
+}
+
+func (r *ReconcileGitTrack) handleGitTrack(gt farosv1alpha1.GitTrackInterface) handlerResult {
+	return handlerResult{}
+}

--- a/pkg/controller/gittrack/handler_test.go
+++ b/pkg/controller/gittrack/handler_test.go
@@ -102,6 +102,15 @@ var _ = Describe("Handler Suite", func() {
 		var gto farosv1alpha1.GitTrackObjectInterface
 		var result handlerResult
 
+		var AssertNoErrors = func() {
+			It("should return no errors", func() {
+				Expect(result.parseError).ToNot(HaveOccurred())
+				Expect(result.gitError).ToNot(HaveOccurred())
+				Expect(result.gcError).ToNot(HaveOccurred())
+				Expect(result.upToDateError).ToNot(HaveOccurred())
+			})
+		}
+
 		var AssertChild = func() {
 			It("creates a GitTrackObject the child", func() {
 				m.Get(gto, timeout).Should(Succeed())
@@ -137,12 +146,7 @@ var _ = Describe("Handler Suite", func() {
 				AssertChild()
 			})
 
-			It("should return no errors", func() {
-				Expect(result.parseError).ToNot(HaveOccurred())
-				Expect(result.gitError).ToNot(HaveOccurred())
-				Expect(result.gcError).ToNot(HaveOccurred())
-				Expect(result.upToDateError).ToNot(HaveOccurred())
-			})
+			AssertNoErrors()
 		}
 
 		var AssertMultiDocument = func() {
@@ -164,12 +168,20 @@ var _ = Describe("Handler Suite", func() {
 				AssertChild()
 			})
 
-			It("should return no errors", func() {
-				Expect(result.parseError).ToNot(HaveOccurred())
-				Expect(result.gitError).ToNot(HaveOccurred())
-				Expect(result.gcError).ToNot(HaveOccurred())
-				Expect(result.upToDateError).ToNot(HaveOccurred())
+			AssertNoErrors()
+		}
+
+		var AssertClusterScopedResource = func() {
+			Context("for the namespace file", func() {
+				BeforeEach(func() {
+					gto = testutils.ExampleClusterGitTrackObject.DeepCopy()
+					gto.SetName("namespace-test")
+				})
+
+				AssertChild()
 			})
+
+			AssertNoErrors()
 		}
 
 		Context("with a GitTrack", func() {
@@ -202,6 +214,14 @@ var _ = Describe("Handler Suite", func() {
 
 				AssertMultiDocument()
 			})
+
+			Context("with a cluster scoped resource", func() {
+				BeforeEach(func() {
+					m.UpdateWithFunc(gt, setGitTrackReferenceFunc(repositoryURL, "b17c0e0f45beca3f1c1e62a7f49fecb738c60d42"), timeout).Should(Succeed())
+				})
+
+				AssertClusterScopedResource()
+			})
 		})
 
 		Context("with a ClusterGitTrack", func() {
@@ -233,6 +253,14 @@ var _ = Describe("Handler Suite", func() {
 				})
 
 				AssertMultiDocument()
+			})
+
+			Context("with a cluster scoped resource", func() {
+				BeforeEach(func() {
+					m.UpdateWithFunc(gt, setGitTrackReferenceFunc(repositoryURL, "b17c0e0f45beca3f1c1e62a7f49fecb738c60d42"), timeout).Should(Succeed())
+				})
+
+				AssertClusterScopedResource()
 			})
 		})
 	})

--- a/pkg/controller/gittrack/handler_test.go
+++ b/pkg/controller/gittrack/handler_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gittrack
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
+	farosflags "github.com/pusher/faros/pkg/flags"
+	farosclient "github.com/pusher/faros/pkg/utils/client"
+	testutils "github.com/pusher/faros/test/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var _ = Describe("Handler Suite", func() {
+	var m testutils.Matcher
+	var r *ReconcileGitTrack
+	var mgr manager.Manager
+	var stop chan struct{}
+
+	const timeout = time.Second * 5
+	const consistentlyTimeout = time.Second
+
+	var setGitTrackReference = func(gt farosv1alpha1.GitTrackInterface, repo, reference string) {
+		spec := gt.GetSpec()
+		spec.Repository = repo
+		spec.Reference = reference
+		gt.SetSpec(spec)
+	}
+
+	BeforeEach(func() {
+		// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
+		// channel when it is finished.
+		var err error
+		cfg.RateLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
+		mgr, err = manager.New(cfg, manager.Options{
+			Namespace:          farosflags.Namespace,
+			MetricsBindAddress: "0", // Disable serving metrics while testing
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		applier, err := farosclient.NewApplier(cfg, farosclient.Options{})
+		Expect(err).NotTo(HaveOccurred())
+
+		c, err := client.New(mgr.GetConfig(), client.Options{})
+		Expect(err).NotTo(HaveOccurred())
+
+		m = testutils.Matcher{Client: c, FarosClient: applier}
+
+		recFn := newReconciler(mgr)
+		r = recFn.(*ReconcileGitTrack)
+
+		stop = StartTestManager(mgr)
+	})
+
+	AfterEach(func() {
+		// Stop Controller and informers before cleaning up
+		close(stop)
+
+		// Clean up all resources as GC is disabled in the control plane
+		testutils.DeleteAll(cfg, timeout,
+			&farosv1alpha1.GitTrackList{},
+			&farosv1alpha1.ClusterGitTrackList{},
+			&farosv1alpha1.GitTrackObjectList{},
+			&farosv1alpha1.ClusterGitTrackObjectList{},
+			&corev1.EventList{},
+		)
+	})
+
+	Context("handleGitTrack", func() {
+		var result handlerResult
+
+		var AssertValidChildren = func() {
+			It("creates a GitTrackObject for the child deployment", func() {
+				gto := testutils.ExampleGitTrackObject.DeepCopy()
+				gto.SetName("deployment-nginx")
+				m.Get(gto, timeout).Should(Succeed())
+			})
+
+			It("creates a GitTrackObject for the child service", func() {
+				gto := testutils.ExampleGitTrackObject.DeepCopy()
+				gto.SetName("service-nginx")
+				m.Get(gto, timeout).Should(Succeed())
+			})
+
+			It("should return no errors", func() {
+				Expect(result.parseError).ToNot(HaveOccurred())
+				Expect(result.gitError).ToNot(HaveOccurred())
+				Expect(result.gcError).ToNot(HaveOccurred())
+				Expect(result.upToDateError).ToNot(HaveOccurred())
+			})
+		}
+
+		Context("with a GitTrack", func() {
+			var gt *farosv1alpha1.GitTrack
+
+			BeforeEach(func() {
+				gt = testutils.ExampleGitTrack.DeepCopy()
+				setGitTrackReference(gt, repositoryURL, "a14443638218c782b84cae56a14f1090ee9e5c9c")
+
+				r = r.withValues(
+					"namespace", gt.GetNamespace(),
+					"name", gt.GetName(),
+				)
+
+				// Create and fetch the instance to make sure caches are synced
+				m.Create(gt).Should(Succeed())
+				m.Get(gt, timeout).Should(Succeed())
+			})
+
+			JustBeforeEach(func() {
+				result = r.handleGitTrack(gt)
+			})
+
+			Context("with valid children", func() {
+				AssertValidChildren()
+			})
+		})
+
+		Context("with a ClusterGitTrack", func() {
+			var gt *farosv1alpha1.ClusterGitTrack
+
+			BeforeEach(func() {
+				gt = testutils.ExampleClusterGitTrack.DeepCopy()
+				setGitTrackReference(gt, repositoryURL, "a14443638218c782b84cae56a14f1090ee9e5c9c")
+
+				r = r.withValues(
+					"namespace", gt.GetNamespace(),
+					"name", gt.GetName(),
+				)
+
+				// Create and fetch the instance to make sure caches are synced
+				m.Create(gt).Should(Succeed())
+				m.Get(gt, timeout).Should(Succeed())
+			})
+
+			JustBeforeEach(func() {
+				result = r.handleGitTrack(gt)
+			})
+
+			Context("with valid children", func() {
+				AssertValidChildren()
+			})
+		})
+	})
+})

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -48,6 +48,10 @@ type Object interface {
 	metav1.Object
 }
 
+// UpdateFunc modifies the object fetched from the API server before sending
+// the update
+type UpdateFunc func(Object) Object
+
 // Apply creates or updates the object on the API server
 func (m *Matcher) Apply(obj Object, opts *farosclient.ApplyOptions, extras ...interface{}) gomega.GomegaAssertion {
 	err := m.FarosClient.Apply(context.TODO(), opts, obj)
@@ -70,6 +74,23 @@ func (m *Matcher) Delete(obj Object, extras ...interface{}) gomega.GomegaAsserti
 func (m *Matcher) Update(obj Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
 	update := func() error {
 		return m.Client.Update(context.TODO(), obj)
+	}
+	return gomega.Eventually(update, intervals...)
+}
+
+// UpdateWithFunc udpates the object on the API server by fetching the object
+// and applying a mutating UpdateFunc before sending the update
+func (m *Matcher) UpdateWithFunc(obj Object, fn UpdateFunc, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+	key := types.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+	update := func() error {
+		err := m.Client.Get(context.TODO(), key, obj)
+		if err != nil {
+			return err
+		}
+		return m.Client.Update(context.TODO(), fn(obj))
 	}
 	return gomega.Eventually(update, intervals...)
 }

--- a/test/utils/owner_ref.go
+++ b/test/utils/owner_ref.go
@@ -21,6 +21,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// GetGitTrackInterfaceOwnerRef constructs an owner reference for the given GT
+func GetGitTrackInterfaceOwnerRef(gt farosv1alpha1.GitTrackInterface) metav1.OwnerReference {
+	var kind string
+	switch gt.(type) {
+	case *farosv1alpha1.GitTrack:
+		kind = "GitTrack"
+	case *farosv1alpha1.ClusterGitTrack:
+		kind = "ClusterGitTrack"
+	default:
+		panic("This code should not be reachable")
+	}
+
+	t := true
+	return metav1.OwnerReference{
+		APIVersion:         "faros.pusher.com/v1alpha1",
+		Kind:               kind,
+		Name:               gt.GetName(),
+		UID:                gt.GetUID(),
+		Controller:         &t,
+		BlockOwnerDeletion: &t,
+	}
+}
+
 // GetGitTrackObjectOwnerRef constructs an owner reference for the given GTO
 func GetGitTrackObjectOwnerRef(gto *farosv1alpha1.GitTrackObject) metav1.OwnerReference {
 	t := true

--- a/test/utils/test_objects.go
+++ b/test/utils/test_objects.go
@@ -55,10 +55,35 @@ func SetGitTrackObjectInterfaceSpec(gto farosv1alpha1.GitTrackObjectInterface, o
 	return nil
 }
 
+// ExampleGitTrack is an example GitTrack object for use within test suites
+var ExampleGitTrack = &farosv1alpha1.GitTrack{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "faros.pusher.com/v1alpha1",
+		Kind:       "GitTrack",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "example",
+		Namespace: "default",
+	},
+	Spec: farosv1alpha1.GitTrackSpec{},
+}
+
+// ExampleClusterGitTrack is an example ClusterGitTrack object for use within test suites
+var ExampleClusterGitTrack = &farosv1alpha1.ClusterGitTrack{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "faros.pusher.com/v1alpha1",
+		Kind:       "ClusterGitTrack",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "example",
+	},
+	Spec: farosv1alpha1.GitTrackSpec{},
+}
+
 // ExampleGitTrackObject is an example GitTrackObject object for use within test suites
 var ExampleGitTrackObject = &farosv1alpha1.GitTrackObject{
 	TypeMeta: metav1.TypeMeta{
-		APIVersion: "faros.pusher.com/v1",
+		APIVersion: "faros.pusher.com/v1alpha1",
 		Kind:       "GitTrackObject",
 	},
 	ObjectMeta: metav1.ObjectMeta{
@@ -94,7 +119,7 @@ var ExampleGitTrackObject = &farosv1alpha1.GitTrackObject{
 // ExampleClusterGitTrackObject is an example ClusterGitTrackObject object for use within test suites
 var ExampleClusterGitTrackObject = &farosv1alpha1.ClusterGitTrackObject{
 	TypeMeta: metav1.TypeMeta{
-		APIVersion: "faros.pusher.com/v1",
+		APIVersion: "faros.pusher.com/v1alpha1",
 		Kind:       "ClusterGitTrackObject",
 	},
 	ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This adds a `handleGitTrack` method as part of a refactor of the gittrack controller.

This adds tests which should be easier to add to than the existing controller tests.

The contents of the `handleGitTrack` method is currently just copy and pasted from the `Reconcile` method and has not yet been refactored, nor is it actually being used. It can introduced to the controller `Reconcile` method once it has been tested