### PR TITLE
cross-namespace access improvements

### DIFF
--- a/pkg/controller/gittrack/gittrack_controller.go
+++ b/pkg/controller/gittrack/gittrack_controller.go
@@ -517,16 +517,17 @@ func (r *ReconcileGitTrack) ignoreObject(u *unstructured.Unstructured, owner far
 
 	ownerNamespace := owner.GetNamespace()
 	_, ownerIsGittrack := owner.(*farosv1alpha1.GitTrack)
+	_, ownerIsClusterGittrack := owner.(*farosv1alpha1.ClusterGitTrack)
 	if namespaced {
 		// prevent a gittrack in a namespace from handling objects which are in a different namespace
 		if ownerIsGittrack && ownerNamespace != u.GetNamespace() {
 			return true, fmt.Sprintf("namespace `%s` is not managed by this GitTrack", u.GetNamespace()), nil
-		} else if !ownerIsGittrack && r.clusterGitTrackMode == farosflags.CGTMExcludeNamespaced {
+		} else if ownerIsClusterGittrack && r.clusterGitTrackMode == farosflags.CGTMExcludeNamespaced {
 			return true, "namespaced resources cannot be managed by ClusterGitTrack", nil
 		}
 	}
 
-	if !ownerIsGittrack && r.clusterGitTrackMode == farosflags.CGTMDisabled {
+	if ownerIsClusterGittrack && r.clusterGitTrackMode == farosflags.CGTMDisabled {
 		return true, "ClusterGitTrack handling disabled; ignoring", nil
 	}
 

--- a/pkg/controller/gittrack/gittrack_controller.go
+++ b/pkg/controller/gittrack/gittrack_controller.go
@@ -506,7 +506,7 @@ func (r *ReconcileGitTrack) ignoreObject(u *unstructured.Unstructured, owner far
 
 	// Ignore namespaced objects not in the namespace managed by the controller
 	if namespaced && r.namespace != "" && r.namespace != u.GetNamespace() {
-		r.log.V(1).Info("Object not in namespace", "object namespace", u.GetNamespace(), "managed namespace", farosflags.Namespace)
+		r.log.V(1).Info("Object not in namespace", "object namespace", u.GetNamespace(), "managed namespace", r.namespace)
 		return true, fmt.Sprintf("namespace `%s` is not managed by this Faros", u.GetNamespace()), nil
 	}
 	// Ignore GVKs in the ignoredGVKs set

--- a/pkg/controller/gittrack/gittrack_controller_suite_test.go
+++ b/pkg/controller/gittrack/gittrack_controller_suite_test.go
@@ -29,7 +29,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pusher/faros/pkg/apis"
-	farosflags "github.com/pusher/faros/pkg/flags"
 	"github.com/pusher/faros/test/reporters"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -86,7 +85,6 @@ var _ = BeforeSuite(func() {
 
 	repositoryPath = setupRepository()
 	repositoryURL = fmt.Sprintf("file://%s", repositoryPath)
-	farosflags.Namespace = "default"
 
 	var err error
 	if cfg, err = t.Start(); err != nil {

--- a/pkg/controller/gittrack/gittrack_controller_test.go
+++ b/pkg/controller/gittrack/gittrack_controller_test.go
@@ -95,6 +95,8 @@ var _ = Describe("GitTrack Suite", func() {
 	BeforeEach(func() {
 		// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
 		// channel when it is finished.
+		farosflags.Namespace = "default"
+
 		var err error
 		cfg.RateLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
 		mgr, err = manager.New(cfg, manager.Options{
@@ -129,6 +131,7 @@ var _ = Describe("GitTrack Suite", func() {
 			&farosv1alpha1.ClusterGitTrackObjectList{},
 			&v1.EventList{},
 		)
+		farosflags.Namespace = ""
 	})
 
 	Context("When a GitTrack resource is created", func() {

--- a/pkg/controller/gittrack/handler_test.go
+++ b/pkg/controller/gittrack/handler_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Handler Suite", func() {
 				m.Get(gto, consistentlyTimeout).ShouldNot(Succeed())
 			})
 
-			PIt("ignores the child resource", func() {
+			It("ignores the child resource", func() {
 				key := fmt.Sprintf("%s/%s", gto.GetNamespace(), gto.GetName())
 				value := fmt.Sprintf("namespace `%s` is not managed by this Faros", gto.GetNamespace())
 				Expect(r.ignoredFiles).To(HaveKeyWithValue(key, value))

--- a/pkg/controller/gittrack/handler_test.go
+++ b/pkg/controller/gittrack/handler_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Handler Suite", func() {
 
 			It("ignores the child resource", func() {
 				key := fmt.Sprintf("%s/%s", gto.GetNamespace(), gto.GetName())
-				value := fmt.Sprintf("namespace `%s` is not managed by this Faros", gto.GetNamespace())
+				value := fmt.Sprintf("namespace `%s` is not managed by this GitTrack", gto.GetNamespace())
 				Expect(r.ignoredFiles).To(HaveKeyWithValue(key, value))
 			})
 		}

--- a/pkg/controller/gittrack/handler_test.go
+++ b/pkg/controller/gittrack/handler_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Handler Suite", func() {
 
 			PIt("ignores the child resource", func() {
 				key := fmt.Sprintf("%s/%s", gto.GetNamespace(), gto.GetName())
-				value := fmt.Sprintf("namespace `%s` is not managed by this GitTrack", gto.GetNamespace())
+				value := fmt.Sprintf("namespace `%s` is not managed by this Faros", gto.GetNamespace())
 				Expect(r.ignoredFiles).To(HaveKeyWithValue(key, value))
 			})
 		}

--- a/pkg/controller/gittrack/handler_test.go
+++ b/pkg/controller/gittrack/handler_test.go
@@ -340,8 +340,8 @@ var _ = Describe("Handler Suite", func() {
 
 		var AssertChildNameWithColon = func() {
 			BeforeEach(func() {
-					gto = testutils.ExampleClusterGitTrackObject.DeepCopy()
-					gto.SetName("clusterrole-test-read-ns-pods-svcs")
+				gto = testutils.ExampleClusterGitTrackObject.DeepCopy()
+				gto.SetName("clusterrole-test-read-ns-pods-svcs")
 			})
 
 			It("replaces `:` with `-` in the name", func() {
@@ -452,7 +452,7 @@ var _ = Describe("Handler Suite", func() {
 				var existingGtos *farosv1alpha1.GitTrackObjectList
 				var existingCGtos *farosv1alpha1.ClusterGitTrackObjectList
 
-				BeforeEach(func(){
+				BeforeEach(func() {
 					existingGtos = &farosv1alpha1.GitTrackObjectList{}
 					m.Eventually(existingGtos, timeout).Should(testutils.WithItems(HaveLen(2)))
 					existingCGtos = &farosv1alpha1.ClusterGitTrackObjectList{}
@@ -488,7 +488,7 @@ var _ = Describe("Handler Suite", func() {
 				var existingGtos *farosv1alpha1.GitTrackObjectList
 				var existingCGtos *farosv1alpha1.ClusterGitTrackObjectList
 
-				BeforeEach(func(){
+				BeforeEach(func() {
 					existingGtos = &farosv1alpha1.GitTrackObjectList{}
 					m.Eventually(existingGtos, timeout).Should(testutils.WithItems(HaveLen(2)))
 					existingCGtos = &farosv1alpha1.ClusterGitTrackObjectList{}

--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -28,6 +28,7 @@ import (
 	gittrackobjectutils "github.com/pusher/faros/pkg/controller/gittrackobject/utils"
 
 	"github.com/go-logr/logr"
+	farosflags "github.com/pusher/faros/pkg/flags"
 	"github.com/pusher/faros/pkg/utils"
 	farosclient "github.com/pusher/faros/pkg/utils/client"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -85,6 +86,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		applier:        applier,
 		dryRunVerifier: dryRunVerifier,
 		log:            rlogr.Log.WithName("gittrackobject-controller"),
+		namespace:      farosflags.Namespace,
 	}
 }
 
@@ -163,6 +165,7 @@ type ReconcileGitTrackObject struct {
 	stop        chan struct{}
 	recorder    record.EventRecorder
 	log         logr.Logger
+	namespace   string
 
 	applier        farosclient.Client
 	dryRunVerifier *utils.DryRunVerifier

--- a/pkg/controller/gittrackobject/handler.go
+++ b/pkg/controller/gittrackobject/handler.go
@@ -278,7 +278,7 @@ func (r *ReconcileGitTrackObject) applyChild(found, child *unstructured.Unstruct
 func (r *ReconcileGitTrackObject) sendEvent(gto farosv1alpha1.GitTrackObjectInterface, eventType, reason, messageFmt string, args ...interface{}) {
 	instance := gto.DeepCopyInterface()
 	if instance.GetNamespace() == "" {
-		instance.SetNamespace(farosflags.Namespace)
+		instance.SetNamespace(r.namespace)
 	}
 
 	r.recorder.Eventf(instance, eventType, reason, messageFmt, args...)

--- a/pkg/flags/flagset.go
+++ b/pkg/flags/flagset.go
@@ -41,6 +41,7 @@ var (
 	// FetchTimeout in seconds for fetching changes from repositories
 	FetchTimeout time.Duration
 
+	// ClusterGitTrack specifies which mode we're handling ClusterGitTracks in
 	ClusterGitTrack ClusterGitTrackMode
 
 	// RepositoryDir is the folder on the local filesystem in which Faros should
@@ -82,14 +83,17 @@ func ParseIgnoredResources() (map[schema.GroupVersionResource]interface{}, error
 	return gvrs, nil
 }
 
+// ClusterGitTrackMode specifies which mode we're running ClusterGitTracks in
 type ClusterGitTrackMode int
 
+// Enums for ClusterGitTrackMode
 const (
 	CGTMIncludeNamespaced ClusterGitTrackMode = iota
 	CGTMDisabled
 	CGTMExcludeNamespaced
 )
 
+// String implements the flag.Value interface
 func (cgtm ClusterGitTrackMode) String() string {
 	switch cgtm {
 	case CGTMDisabled:
@@ -102,6 +106,7 @@ func (cgtm ClusterGitTrackMode) String() string {
 	panic("unreachable")
 }
 
+// Set implements the flag.Value interface
 func (cgtm *ClusterGitTrackMode) Set(s string) error {
 	lowered := strings.ToLower(s)
 	switch lowered {
@@ -119,6 +124,7 @@ func (cgtm *ClusterGitTrackMode) Set(s string) error {
 	}
 }
 
+// Type implements the flag.Value interface
 func (cgtm ClusterGitTrackMode) Type() string {
 	return "ClusterGitTrackMode"
 }

--- a/pkg/flags/flagset.go
+++ b/pkg/flags/flagset.go
@@ -57,7 +57,7 @@ func init() {
 	FlagSet.BoolVar(&ServerDryRun, "server-dry-run", true, "Enable/Disable server side dry run before updating resources")
 	FlagSet.DurationVar(&FetchTimeout, "fetch-timeout", 30*time.Second, "Timeout in seconds for fetching changes from repositories")
 	FlagSet.StringVar(&RepositoryDir, "repository-dir", "", "Directory in which to clone repositories. Defaults to cloning in memory if unset.")
-	FlagSet.Var(&ClusterGitTrack, "clustergittrack-mode", "How to manage ClusterGitTracks")
+	FlagSet.Var(&ClusterGitTrack, "clustergittrack-mode", "How to manage ClusterGitTracks. Valid values are Disabled, IncludeNamespaced and ExcludeNamespaced")
 }
 
 // ParseIgnoredResources attempts to parse the ignore-resource flag value and

--- a/pkg/flags/flagset.go
+++ b/pkg/flags/flagset.go
@@ -120,7 +120,7 @@ func (cgtm *ClusterGitTrackMode) Set(s string) error {
 		*cgtm = CGTMExcludeNamespaced
 		return nil
 	default:
-		return fmt.Errorf("invalid value %q for ClusterGitTrackMode", s)
+		return fmt.Errorf("invalid value %q for clustergittrack-mode; valid values are Disabled, IncludeNamespaced and ExcludeNamespaced", s)
 	}
 }
 


### PR DESCRIPTION
This PR implements disallowing GitTracks from managing resources in other namespaces and the flag for the new ClusterGitTrack modes