### PR TITLE
Rewrite tests for fetching Git Credentials

### DIFF
--- a/pkg/controller/gittrack/git_creds.go
+++ b/pkg/controller/gittrack/git_creds.go
@@ -56,7 +56,7 @@ func (r *ReconcileGitTrack) fetchGitCredentials(gt farosv1alpha1.GitTrackInterfa
 		deployKey.SecretNamespace = gt.GetNamespace()
 	case *farosv1alpha1.ClusterGitTrack:
 		if deployKey.SecretNamespace == "" {
-			return nil, fmt.Errorf("No Secret Namespace set for DeployKey")
+			return nil, fmt.Errorf("No SecretNamespace set for DeployKey")
 		}
 	default:
 		panic(fmt.Errorf("This code should not be reachable"))

--- a/pkg/controller/gittrack/git_creds.go
+++ b/pkg/controller/gittrack/git_creds.go
@@ -43,7 +43,7 @@ func (r *ReconcileGitTrack) fetchGitCredentials(gt farosv1alpha1.GitTrackInterfa
 	}
 	// Check the deployKey fields are both non-empty
 	if deployKey.SecretName == "" || deployKey.Key == "" {
-		return nil, fmt.Errorf("if using a deploy key, both SecretName and Key must be set")
+		return nil, fmt.Errorf("both SecretName and Key must be set when using DeployKey")
 	}
 
 	// Set the SecretNamespace to match the GitTrack Namespace
@@ -51,15 +51,15 @@ func (r *ReconcileGitTrack) fetchGitCredentials(gt farosv1alpha1.GitTrackInterfa
 	switch gt.(type) {
 	case *farosv1alpha1.GitTrack:
 		if deployKey.SecretNamespace != "" && deployKey.SecretNamespace != gt.GetNamespace() {
-			return nil, fmt.Errorf("DeployKey namespace must match GitTrack namespace or be empty")
+			return nil, fmt.Errorf("the DeployKey namespace must match GitTrack namespace or be empty")
 		}
 		deployKey.SecretNamespace = gt.GetNamespace()
 	case *farosv1alpha1.ClusterGitTrack:
 		if deployKey.SecretNamespace == "" {
-			return nil, fmt.Errorf("No SecretNamespace set for DeployKey")
+			return nil, fmt.Errorf("no SecretNamespace set for DeployKey")
 		}
 	default:
-		panic(fmt.Errorf("This code should not be reachable"))
+		panic(fmt.Errorf("this code should not be reachable"))
 	}
 
 	// Fetch the secret from the API
@@ -98,8 +98,8 @@ func createRepoRefFromCreds(url string, creds *gitCredentials) (*gitstore.RepoRe
 		if len(credStringSplit) == 2 {
 			return &gitstore.RepoRef{URL: url, User: credStringSplit[0], Pass: credStringSplit[1]}, nil
 		}
-		return nil, fmt.Errorf("You must specify the secret as <username>:<password> for credential type %s", creds.credentialType)
+		return nil, fmt.Errorf("you must specify the secret as <username>:<password> for credential type %s", creds.credentialType)
 	default:
-		return nil, fmt.Errorf("Unable to create repo ref: invalid type \"%s\"", creds.credentialType)
+		return nil, fmt.Errorf("unable to create repo ref: invalid type \"%s\"", creds.credentialType)
 	}
 }

--- a/pkg/controller/gittrack/git_creds.go
+++ b/pkg/controller/gittrack/git_creds.go
@@ -17,16 +17,69 @@ limitations under the License.
 package gittrack
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
 	gitstore "github.com/pusher/git-store"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type gitCredentials struct {
 	secret         []byte
 	credentialType farosv1alpha1.GitCredentialType
+}
+
+// fetchGitCredentials creates git credentials data from a given deployKey secret reference
+func (r *ReconcileGitTrack) fetchGitCredentials(gt farosv1alpha1.GitTrackInterface) (*gitCredentials, error) {
+	deployKey := gt.GetSpec().DeployKey
+
+	// Check if the deployKey is empty, do nothing if it is
+	emptyKey := farosv1alpha1.GitTrackDeployKey{}
+	if deployKey == emptyKey {
+		return nil, nil
+	}
+	// Check the deployKey fields are both non-empty
+	if deployKey.SecretName == "" || deployKey.Key == "" {
+		return nil, fmt.Errorf("if using a deploy key, both SecretName and Key must be set")
+	}
+
+	// Set the SecretNamespace to match the GitTrack Namespace
+	// Users must set this for ClusterGitTracks
+	switch gt.(type) {
+	case *farosv1alpha1.GitTrack:
+		if deployKey.SecretNamespace != "" && deployKey.SecretNamespace != gt.GetNamespace() {
+			return nil, fmt.Errorf("DeployKey namespace must match GitTrack namespace or be empty")
+		}
+		deployKey.SecretNamespace = gt.GetNamespace()
+	case *farosv1alpha1.ClusterGitTrack:
+		if deployKey.SecretNamespace == "" {
+			return nil, fmt.Errorf("No Secret Namespace set for DeployKey")
+		}
+	default:
+		panic(fmt.Errorf("This code should not be reachable"))
+	}
+
+	// Fetch the secret from the API
+	secret := &corev1.Secret{}
+	err := r.Get(context.TODO(), types.NamespacedName{
+		Namespace: deployKey.SecretNamespace,
+		Name:      deployKey.SecretName,
+	}, secret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up secret %s: %v", deployKey.SecretName, err)
+	}
+
+	// Extract the data from the secret
+	var ok bool
+	var secretData []byte
+	if secretData, ok = secret.Data[deployKey.Key]; !ok {
+		return nil, fmt.Errorf("invalid deploy key reference. Secret %s does not have key %s", deployKey.SecretName, deployKey.Key)
+	}
+
+	return &gitCredentials{secret: secretData, credentialType: deployKey.Type}, nil
 }
 
 // createRepoRef creates a git repo ref configured depending on the credentialType

--- a/pkg/controller/gittrack/git_creds_test.go
+++ b/pkg/controller/gittrack/git_creds_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package gittrack
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
@@ -23,15 +25,21 @@ import (
 	testutils "github.com/pusher/faros/test/utils"
 	"k8s.io/client-go/util/flowcontrol"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	farosclient "github.com/pusher/faros/pkg/utils/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("GitTrack Suite", func() {
 	Describe("fetchGitCredentials", func() {
+		var m testutils.Matcher
 		var r *ReconcileGitTrack
 		var mgr manager.Manager
 		var stop chan struct{}
 
 		var gt farosv1alpha1.GitTrackInterface
+		var secret *corev1.Secret
 		var creds *gitCredentials
 		var credsErr error
 
@@ -44,6 +52,14 @@ var _ = Describe("GitTrack Suite", func() {
 				MetricsBindAddress: "0", // Disable serving metrics while testing
 			})
 			Expect(err).NotTo(HaveOccurred())
+
+			applier, err := farosclient.NewApplier(cfg, farosclient.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := client.New(mgr.GetConfig(), client.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			m = testutils.Matcher{Client: c, FarosClient: applier}
 
 			recFn := newReconciler(mgr)
 			r = recFn.(*ReconcileGitTrack)
@@ -59,6 +75,12 @@ var _ = Describe("GitTrack Suite", func() {
 			close(stop)
 		})
 
+		var setDeployKey = func(gt farosv1alpha1.GitTrackInterface, dk farosv1alpha1.GitTrackDeployKey) {
+			spec := gt.GetSpec()
+			spec.DeployKey = dk
+			gt.SetSpec(spec)
+		}
+
 		var AssertNoDeployKey = func() {
 			Context("which has no DeployKey", func() {
 				It("should return no error", func() {
@@ -67,6 +89,143 @@ var _ = Describe("GitTrack Suite", func() {
 
 				It("should return nil credentials", func() {
 					Expect(creds).To(BeNil())
+				})
+			})
+		}
+
+		var AssertWithDeployKey = func() {
+			Context("which has a DeployKey" , func() {
+				var dk farosv1alpha1.GitTrackDeployKey
+
+				var keysMustBeSetErr = errors.New("if using a deploy key, both SecretName and Key must be set")
+				var secretNotFoundErr = errors.New("failed to look up secret nonExistentSecret: Secret \"nonExistentSecret\" not found")
+
+				BeforeEach(func() {
+					By("Creating a secret with a private key")
+					secret = &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foosecret",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"privatekey": []byte("PrivateKey"),
+						},
+					}
+					m.Create(secret).Should(Succeed())
+
+					dk = farosv1alpha1.GitTrackDeployKey{
+						SecretName: "foosecret",
+						SecretNamespace: "default",
+						Key:        "privatekey",
+					}
+					setDeployKey(gt, dk)
+				})
+
+				AfterEach(func() {
+					m.Delete(secret).Should(Succeed())
+				})
+
+				Context("if the secret exists", func() {
+					It("retrieves the private key from the secret", func() {
+						Expect(creds).ToNot(BeNil())
+						Expect(creds.secret).To(Equal(secret.Data["privatekey"]))
+					})
+				})
+
+				Context("if the secret does not exist", func() {
+					BeforeEach(func() {
+						dk.SecretName = "nonExistentSecret"
+						setDeployKey(gt, dk)
+					})
+
+					It("returns an error", func() {
+						Expect(credsErr).ToNot(BeNil())
+						Expect(credsErr).To(Equal(secretNotFoundErr))
+					})
+
+					It("returns nil credentials", func() {
+						Expect(creds).To(BeNil())
+					})
+				})
+
+				Context("if a key is not set within the DeployKey", func () {
+					BeforeEach(func() {
+						dk.Key = ""
+						setDeployKey(gt, dk)
+					})
+
+					Context("but the secret name is", func() {
+						It("returns an error", func() {
+							Expect(credsErr).ToNot(BeNil())
+							Expect(credsErr).To(Equal(keysMustBeSetErr))
+						})
+
+						It("returns nil credentials", func() {
+							Expect(creds).To(BeNil())
+						})
+					})
+				})
+
+				Context("if the secret name is not set within the DeployKey", func () {
+					BeforeEach(func() {
+						dk.SecretName = ""
+						setDeployKey(gt, dk)
+					})
+
+					Context("but the key name is", func() {
+						It("returns an error", func() {
+							Expect(credsErr).ToNot(BeNil())
+							Expect(credsErr).To(Equal(keysMustBeSetErr))
+						})
+
+						It("returns nil credentials", func() {
+							Expect(creds).To(BeNil())
+						})
+					})
+				})
+
+				Context("if the secret namespace is not set", func() {
+					BeforeEach(func() {
+						dk.SecretNamespace = ""
+						setDeployKey(gt, dk)
+					})
+
+					Context("with a GitTrack", func() {
+						It("fetches the secret from the GitTrack's Namespace", func() {
+							if _, ok := gt.(*farosv1alpha1.GitTrack); !ok {
+								Skip("test behaviour is for GitTracks only")
+							}
+
+							Expect(creds).ToNot(BeNil())
+							Expect(creds.secret).To(Equal(secret.Data["privatekey"]))
+						})
+
+						It("should return no error", func() {
+							if _, ok := gt.(*farosv1alpha1.GitTrack); !ok {
+								Skip("test behaviour is for GitTracks only")
+							}
+
+							Expect(credsErr).To(BeNil())
+						})
+					})
+
+					Context("With a ClusterGitTrack", func() {
+						It("returns an error", func() {
+							if _, ok := gt.(*farosv1alpha1.ClusterGitTrack); !ok {
+								Skip("test behaviour is for ClusterGitTracks only")
+							}
+
+							Expect(credsErr).To(Equal(errors.New("No SecretNamespace set for DeployKey")))
+						})
+
+						It("returns nil credentials", func() {
+							if _, ok := gt.(*farosv1alpha1.ClusterGitTrack); !ok {
+								Skip("test behaviour is for ClusterGitTracks only")
+							}
+
+							Expect(creds).To(BeNil())
+						})
+					})
 				})
 			})
 		}
@@ -81,6 +240,7 @@ var _ = Describe("GitTrack Suite", func() {
 			})
 
 			AssertNoDeployKey()
+			AssertWithDeployKey()
 		})
 
 		Context("With a ClusterGitTrack", func() {
@@ -89,6 +249,7 @@ var _ = Describe("GitTrack Suite", func() {
 			})
 
 			AssertNoDeployKey()
+			AssertWithDeployKey()
 		})
 	})
 

--- a/pkg/controller/gittrack/git_creds_test.go
+++ b/pkg/controller/gittrack/git_creds_test.go
@@ -97,7 +97,7 @@ var _ = Describe("GitTrack Suite", func() {
 			Context("which has a DeployKey" , func() {
 				var dk farosv1alpha1.GitTrackDeployKey
 
-				var keysMustBeSetErr = errors.New("if using a deploy key, both SecretName and Key must be set")
+				var keysMustBeSetErr = errors.New("both SecretName and Key must be set when using DeployKey")
 				var secretNotFoundErr = errors.New("failed to look up secret nonExistentSecret: Secret \"nonExistentSecret\" not found")
 
 				BeforeEach(func() {
@@ -215,7 +215,7 @@ var _ = Describe("GitTrack Suite", func() {
 								Skip("test behaviour is for ClusterGitTracks only")
 							}
 
-							Expect(credsErr).To(Equal(errors.New("No SecretNamespace set for DeployKey")))
+							Expect(credsErr).To(Equal(errors.New("no SecretNamespace set for DeployKey")))
 						})
 
 						It("returns nil credentials", func() {
@@ -295,7 +295,7 @@ var _ = Describe("GitTrack Suite", func() {
 				It("returns an error", func() {
 					Expect(repo).To(BeNil())
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("You must specify the secret as <username>:<password> for credential type HTTPBasicAuth"))
+					Expect(err.Error()).To(Equal("you must specify the secret as <username>:<password> for credential type HTTPBasicAuth"))
 				})
 			})
 		})

--- a/pkg/controller/gittrack/gittrack_controller.go
+++ b/pkg/controller/gittrack/gittrack_controller.go
@@ -208,56 +208,6 @@ func (r *ReconcileGitTrack) checkoutRepo(url string, ref string, gitCreds *gitCr
 	return repo, nil
 }
 
-// fetchGitCredentials creates git credentials data from a given deployKey secret reference
-func (r *ReconcileGitTrack) fetchGitCredentials(gt farosv1alpha1.GitTrackInterface) (*gitCredentials, error) {
-	deployKey := gt.GetSpec().DeployKey
-
-	// Check if the deployKey is empty, do nothing if it is
-	emptyKey := farosv1alpha1.GitTrackDeployKey{}
-	if deployKey == emptyKey {
-		return nil, nil
-	}
-	// Check the deployKey fields are both non-empty
-	if deployKey.SecretName == "" || deployKey.Key == "" {
-		return nil, fmt.Errorf("if using a deploy key, both SecretName and Key must be set")
-	}
-
-	// Set the SecretNamespace to match the GitTrack Namespace
-	// Users must set this for ClusterGitTracks
-	switch gt.(type) {
-	case *farosv1alpha1.GitTrack:
-		if deployKey.SecretNamespace != "" && deployKey.SecretNamespace != gt.GetNamespace() {
-			return nil, fmt.Errorf("DeployKey namespace must match GitTrack namespace or be empty")
-		}
-		deployKey.SecretNamespace = gt.GetNamespace()
-	case *farosv1alpha1.ClusterGitTrack:
-		if deployKey.SecretNamespace == "" {
-			return nil, fmt.Errorf("No Secret Namespace set for DeployKey")
-		}
-	default:
-		panic(fmt.Errorf("This code should not be reachable"))
-	}
-
-	// Fetch the secret from the API
-	secret := &apiv1.Secret{}
-	err := r.Get(context.TODO(), types.NamespacedName{
-		Namespace: deployKey.SecretNamespace,
-		Name:      deployKey.SecretName,
-	}, secret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to look up secret %s: %v", deployKey.SecretName, err)
-	}
-
-	// Extract the data from the secret
-	var ok bool
-	var secretData []byte
-	if secretData, ok = secret.Data[deployKey.Key]; !ok {
-		return nil, fmt.Errorf("invalid deploy key reference. Secret %s does not have key %s", deployKey.SecretName, deployKey.Key)
-	}
-
-	return &gitCredentials{secret: secretData, credentialType: deployKey.Type}, nil
-}
-
 // getFiles checks out the Spec.Repository at Spec.Reference and returns a map of filename to
 // gitstore.File pointers
 func (r *ReconcileGitTrack) getFiles(gt farosv1alpha1.GitTrackInterface) (map[string]*gitstore.File, error) {


### PR DESCRIPTION
This rewrites the tests for fetching Git Credentials so that they work with both GitTrack and ClusterGitTrack resources.

Also adds test for the behaviour of setting the `DeployKey.SecretNamespace` field and removes the old tests that were in the main GitTrack test file