### PR TITLE
Tests for files-related functions

### DIFF
--- a/pkg/controller/gittrack/files.go
+++ b/pkg/controller/gittrack/files.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gittrack
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
+	farosflags "github.com/pusher/faros/pkg/flags"
+	utils "github.com/pusher/faros/pkg/utils"
+	gitstore "github.com/pusher/git-store"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// checkoutRepo checks out the repository at reference and returns a pointer to said repository
+func (r *ReconcileGitTrack) checkoutRepo(url string, ref string, gitCreds *gitCredentials) (*gitstore.Repo, error) {
+	r.log.V(1).Info("Getting repository", "url", url)
+	repoRef, err := createRepoRefFromCreds(url, gitCreds)
+	if err != nil {
+		return &gitstore.Repo{}, err
+	}
+	rc, done, err := r.store.GetAsync(repoRef)
+	if err != nil {
+		return &gitstore.Repo{}, fmt.Errorf("failed to get repository '%s': %v'", url, err)
+	}
+	repo := &gitstore.Repo{}
+
+	select {
+	case <-done:
+		if rc.Error != nil {
+			return repo, fmt.Errorf("failed to get repository '%s': %v'", url, rc.Error)
+		}
+		repo = rc.Repo
+	case <-time.After(farosflags.FetchTimeout):
+		return repo, fmt.Errorf("timed out getting repository '%s'", url)
+	}
+
+	r.log.V(1).Info("Checking out reference", "reference", ref)
+	ctx, cancel := context.WithTimeout(context.Background(), farosflags.FetchTimeout)
+	defer cancel()
+	err = repo.CheckoutContext(ctx, ref)
+	if err != nil {
+		return &gitstore.Repo{}, fmt.Errorf("failed to checkout '%s': %v", ref, err)
+	}
+
+	lastUpdated, err := repo.LastUpdated()
+	if err != nil {
+		return &gitstore.Repo{}, fmt.Errorf("failed to get last updated timestamp: %v", err)
+	}
+
+	r.mutex.Lock()
+	r.lastUpdateTimes[url] = lastUpdated
+	r.mutex.Unlock()
+
+	return repo, nil
+}
+
+// getFiles checks out the Spec.Repository at Spec.Reference and returns a map of filename to
+// gitstore.File pointers
+func (r *ReconcileGitTrack) getFiles(gt farosv1alpha1.GitTrackInterface) (map[string]*gitstore.File, error) {
+	r.recorder.Eventf(gt, corev1.EventTypeNormal, "CheckoutStarted", "Checking out '%s' at '%s'", gt.GetSpec().Repository, gt.GetSpec().Reference)
+	gitCreds, err := r.fetchGitCredentials(gt)
+	if err != nil {
+		r.recorder.Eventf(gt, corev1.EventTypeWarning, "CheckoutFailed", "Failed to checkout '%s' at '%s'", gt.GetSpec().Repository, gt.GetSpec().Reference)
+		return nil, fmt.Errorf("unable to retrieve git credentials from secret: %v", err)
+	}
+
+	repo, err := r.checkoutRepo(gt.GetSpec().Repository, gt.GetSpec().Reference, gitCreds)
+	if err != nil {
+		r.recorder.Eventf(gt, corev1.EventTypeWarning, "CheckoutFailed", "Failed to checkout '%s' at '%s'", gt.GetSpec().Repository, gt.GetSpec().Reference)
+		return nil, err
+	}
+
+	subPath := gt.GetSpec().SubPath
+	if !strings.HasSuffix(subPath, "/") {
+		subPath += "/"
+	}
+
+	r.log.V(1).Info("Loading files from subpath", "subpath", subPath)
+	globbedSubPath := strings.TrimPrefix(subPath, "/") + "{**/*,*}.{yaml,yml,json}"
+	files, err := repo.GetAllFiles(globbedSubPath, true)
+	if err != nil {
+		r.recorder.Eventf(gt, corev1.EventTypeWarning, "CheckoutFailed", "Failed to get files for SubPath '%s'", gt.GetSpec().SubPath)
+		return nil, fmt.Errorf("failed to get all files for subpath '%s': %v", gt.GetSpec().SubPath, err)
+	} else if len(files) == 0 {
+		r.recorder.Eventf(gt, corev1.EventTypeWarning, "CheckoutFailed", "No files for SubPath '%s'", gt.GetSpec().SubPath)
+		return nil, fmt.Errorf("no files for subpath '%s'", gt.GetSpec().SubPath)
+	}
+
+	r.log.V(1).Info("Loaded files from repository", "file count", len(files))
+	return files, nil
+}
+
+// objectsFrom iterates through all the files given and attempts to create Unstructured objects
+func objectsFrom(files map[string]*gitstore.File) ([]*unstructured.Unstructured, map[string]string) {
+	objects := []*unstructured.Unstructured{}
+	fileErrors := make(map[string]string)
+	for path, file := range files {
+		// TODO (@JoelSpeed): What happens if there are multiple resources in one file,
+		// but one of them is invalid? Can we still get the rest?
+		us, err := utils.YAMLToUnstructuredSlice([]byte(file.Contents()))
+		if err != nil {
+			fileErrors[path] = fmt.Sprintf("unable to parse '%s': %v\n", path, err)
+			continue
+		}
+		objects = append(objects, us...)
+	}
+	return objects, fileErrors
+}

--- a/pkg/controller/gittrack/files_test.go
+++ b/pkg/controller/gittrack/files_test.go
@@ -16,56 +16,385 @@ limitations under the License.
 package gittrack
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	farosv1alpha1 "github.com/pusher/faros/pkg/apis/faros/v1alpha1"
+	farosflags "github.com/pusher/faros/pkg/flags"
+	farosclient "github.com/pusher/faros/pkg/utils/client"
+	testutils "github.com/pusher/faros/test/utils"
+	gitstore "github.com/pusher/git-store"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-  gitstore "github.com/pusher/git-store"
 )
 
 var _ = Describe("GitTrack Suite", func() {
-	Describe("checkoutRepo", func() {
-		var r *ReconcileGitTrack
-		var mgr manager.Manager
+	var r *ReconcileGitTrack
+	var mgr manager.Manager
+	var m testutils.Matcher
+	var subPath string
+	var reference string
+	var url string
+	var stop chan struct{}
+	var gt farosv1alpha1.GitTrackInterface
 
+	const timeout = 5 * time.Second
+
+	var setupSpec = func(gt farosv1alpha1.GitTrackInterface, reference, url, subpath string) {
+		spec := gt.GetSpec()
+		spec.Repository = url
+		spec.Reference = reference
+		spec.SubPath = subpath
+		gt.SetSpec(spec)
+	}
+
+	BeforeEach(func() {
+		var err error
+		cfg.RateLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
+		mgr, err = manager.New(cfg, manager.Options{
+			MetricsBindAddress: "0", // Disable serving metrics while testing
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		applier, err := farosclient.NewApplier(cfg, farosclient.Options{})
+		Expect(err).NotTo(HaveOccurred())
+
+		c, err := client.New(mgr.GetConfig(), client.Options{})
+		Expect(err).NotTo(HaveOccurred())
+
+		m = testutils.Matcher{Client: c, FarosClient: applier}
+
+		recFn, _ := newReconciler(mgr)
+		r = recFn.(*ReconcileGitTrack)
+
+		stop = StartTestManager(mgr)
+
+		// Reset defaults before each test
+		url = repositoryURL
+		reference = "936b7ee3df1dbd61b1fc691b742fa5d5d3c0dced"
+		subPath = ""
+		gt = nil
+	})
+
+	JustBeforeEach(func() {
+		// Not all tests depend on a {Cluster,}GitTrack
+		if gt != nil {
+			setupSpec(gt, reference, url, subPath)
+		}
+	})
+
+	AfterEach(func() {
+		// Stop Controller and informers before cleaning up
+		close(stop)
+
+		testutils.DeleteAll(cfg, timeout, &corev1.EventList{})
+	})
+
+	Describe("checkoutRepo", func() {
 		var checkoutErr error
 		var repo *gitstore.Repo
-		var url string
-		var reference string
 		var credentials *gitCredentials
-
-		BeforeEach(func() {
-			// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
-			// channel when it is finished.
-			var err error
-			cfg.RateLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
-			mgr, err = manager.New(cfg, manager.Options{
-				MetricsBindAddress: "0", // Disable serving metrics while testing
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			recFn := newReconciler(mgr)
-			r = recFn.(*ReconcileGitTrack)
-
-			repo = nil
-			checkoutErr = nil
-			url = repositoryURL
-			reference = "master"
-			credentials = nil
-		})
 
 		JustBeforeEach(func() {
 			repo, checkoutErr = r.checkoutRepo(url, reference, credentials)
 		})
 
-		Context("when no credentials are provided or required", func() {
-			It("checks out the repository", func() {
+		Context("when no credentials are required", func() {
+			It("returns a repository", func() {
 				Expect(repo).ToNot(BeNil())
 			})
 
 			It("does not return an error", func() {
 				Expect(checkoutErr).ToNot(HaveOccurred())
 			})
+
+			It("sets the last updated time", func() {
+				ts, _ := time.Parse(time.RFC3339, "2019-04-03T10:11:54+01:00")
+				Expect(r.lastUpdateTimes).To(HaveKeyWithValue(url, BeTemporally("==", ts)))
+			})
 		})
-  })
+
+		PContext("when given invalid credentials", func() {
+			BeforeEach(func() {
+				url = "git@github.com:"
+			})
+
+			It("returns an error", func() {
+				Expect(checkoutErr).ToNot(BeNil())
+			})
+		})
+
+		Context("when given an invalid repository URL", func() {
+			BeforeEach(func() {
+				url = repositoryURL + "-invalid"
+			})
+
+			It("returns an error", func() {
+				Expect(checkoutErr).To(MatchError(MatchRegexp("failed to get repository '%s': repository not found'", url)))
+			})
+		})
+
+		Context("when given an invalid reference", func() {
+			BeforeEach(func() {
+				reference = "invalid-reference"
+			})
+
+			It("returns an error", func() {
+				Expect(checkoutErr).To(MatchError(MatchRegexp("failed to checkout '%s': unable to parse ref %s: reference not found", reference, reference)))
+			})
+		})
+
+		Context("when the checkout times out", func() {
+			var fetchTimeout time.Duration
+
+			BeforeEach(func() {
+				fetchTimeout = farosflags.FetchTimeout
+				farosflags.FetchTimeout = 0 * time.Second
+			})
+
+			AfterEach(func() {
+				farosflags.FetchTimeout = fetchTimeout
+			})
+
+			It("returns an error", func() {
+				Expect(checkoutErr).To(MatchError(MatchRegexp("timed out getting repository '%s'", url)))
+			})
+		})
+	})
+
+	Describe("getFiles", func() {
+		var files map[string]*gitstore.File
+		var filesErr error
+
+		JustBeforeEach(func() {
+			files, filesErr = r.getFiles(gt)
+		})
+
+		var AssertSendsEvent = func(reason, kind, name, eventType string) {
+			It(fmt.Sprintf("sends a %s event", reason), func() {
+				events := &corev1.EventList{}
+				m.Eventually(events, timeout).Should(testutils.WithItems(ContainElement(SatisfyAll(
+					testutils.WithField("Reason", Equal(reason)),
+					testutils.WithField("Type", Equal(eventType)),
+					testutils.WithField("InvolvedObject.Kind", Equal(kind)),
+					testutils.WithField("InvolvedObject.Name", Equal(name)),
+				))))
+			})
+		}
+
+		var AssertValidSubPath = func() {
+			Context("with a subPath that contains files", func() {
+				It("returns files", func() {
+					Expect(files).ToNot(BeEmpty())
+				})
+
+				It("recursively finds files", func() {
+					Expect(files).To(HaveLen(12))
+				})
+
+				It("filters files by extension", func() {
+					for path := range files {
+						Expect(path).To(SatisfyAny(
+							HaveSuffix(".yaml"),
+							HaveSuffix(".yml"),
+							HaveSuffix(".json"),
+						))
+					}
+				})
+
+				It("does not return an error", func() {
+					Expect(filesErr).To(BeNil())
+				})
+			})
+		}
+
+		var AssertSubPathWithoutTrailingSlash = func(prefix string, count int) {
+			Context("with a subPath that does not end with a slash", func() {
+				BeforeEach(func() {
+					subPath = prefix
+					reference = "51798af1c1374d1d375a0eb7a3e53dd67ac5d135"
+				})
+
+				It("returns files", func() {
+					Expect(files).To(HaveLen(count))
+				})
+
+				It("does not return files from other directories with a similar prefix", func() {
+					for path := range files {
+						Expect(path).To(HavePrefix(prefix + "/"))
+					}
+				})
+
+				It("filters files by extension", func() {
+					for path := range files {
+						Expect(path).To(SatisfyAny(
+							HaveSuffix(".yaml"),
+							HaveSuffix(".yml"),
+							HaveSuffix(".json"),
+						))
+					}
+				})
+
+				It("does not return an error", func() {
+					Expect(filesErr).To(BeNil())
+				})
+			})
+		}
+
+		var AssertSubPathWithLeadingSlash = func(prefix string, count int) {
+			Context("subPath with leading slash", func() {
+				BeforeEach(func() {
+					subPath = prefix
+					reference = "51798af1c1374d1d375a0eb7a3e53dd67ac5d135"
+				})
+
+				It("returns files", func() {
+					Expect(files).To(HaveLen(count))
+				})
+
+				It("does not return files from directories with a similar prefix", func() {
+					for path := range files {
+						Expect(path).To(HavePrefix(strings.TrimPrefix(prefix, "/") + "/"))
+					}
+				})
+
+				It("filters files by extension", func() {
+					for path := range files {
+						Expect(path).To(SatisfyAny(
+							HaveSuffix(".yaml"),
+							HaveSuffix(".yml"),
+							HaveSuffix(".json"),
+						))
+					}
+				})
+
+				It("does not return any error", func() {
+					Expect(filesErr).To(BeNil())
+				})
+			})
+		}
+
+		var AssertEmptySubPath = func(kind string) {
+			Context("with a subPath that does not contain any files", func() {
+				BeforeEach(func() {
+					subPath = "non-existent-path"
+				})
+
+				It("does not return any files", func() {
+					Expect(files).To(BeEmpty())
+				})
+
+				It("returns an error", func() {
+					Expect(filesErr).To(MatchError(MatchRegexp("no files for subpath '%s'", subPath)))
+				})
+
+				AssertSendsEvent("CheckoutFailed", kind, "example", corev1.EventTypeWarning)
+			})
+		}
+
+		Context("with a GitTrack", func() {
+			const kind = "GitTrack"
+
+			BeforeEach(func() {
+				gt = testutils.ExampleGitTrack.DeepCopy()
+			})
+
+			AssertSendsEvent("CheckoutStarted", kind, "example", corev1.EventTypeNormal)
+			AssertValidSubPath()
+			AssertSubPathWithoutTrailingSlash("foo", 3)
+			AssertSubPathWithoutTrailingSlash("foobar", 2)
+			AssertSubPathWithLeadingSlash("/foo", 3)
+			AssertSubPathWithLeadingSlash("/foobar", 2)
+			AssertEmptySubPath(kind)
+		})
+
+		Context("with a ClusterGitTrack", func() {
+			const kind = "ClusterGitTrack"
+
+			BeforeEach(func() {
+				gt = testutils.ExampleClusterGitTrack.DeepCopy()
+			})
+
+			AssertSendsEvent("CheckoutStarted", kind, "example", corev1.EventTypeNormal)
+			AssertValidSubPath()
+			AssertSubPathWithoutTrailingSlash("foo", 3)
+			AssertSubPathWithoutTrailingSlash("foobar", 2)
+			AssertSubPathWithLeadingSlash("/foo", 3)
+			AssertSubPathWithLeadingSlash("/foobar", 2)
+			AssertEmptySubPath(kind)
+		})
+	})
+
+	Describe("objectsFrom", func() {
+		var objects []*unstructured.Unstructured
+		var parseErrs map[string]string
+
+		BeforeEach(func() {
+			gt = testutils.ExampleGitTrack.DeepCopy()
+		})
+
+		JustBeforeEach(func() {
+			files, err := r.getFiles(gt)
+			Expect(err).ToNot(HaveOccurred())
+			objects, parseErrs = objectsFrom(files)
+		})
+
+		Context("with valid YAML files", func() {
+			BeforeEach(func() {
+				reference = "a14443638218c782b84cae56a14f1090ee9e5c9c"
+			})
+
+			It("returns objects", func() {
+				Expect(objects).To(HaveLen(2))
+			})
+
+			It("does not return any errors", func() {
+				Expect(parseErrs).To(BeEmpty())
+			})
+		})
+
+		Context("with valid multi-document YAML files", func() {
+			BeforeEach(func() {
+				reference = "9bf412f0e893c8c1624bb1c523cfeca8243534bc"
+			})
+
+			It("returns all expected objects", func() {
+				Expect(objects).To(HaveLen(5))
+			})
+
+			It("does not return any errors", func() {
+				Expect(parseErrs).To(BeEmpty())
+			})
+		})
+
+		Context("with invalid YAML files", func() {
+			BeforeEach(func() {
+				reference = "936b7ee3df1dbd61b1fc691b742fa5d5d3c0dced"
+			})
+
+			It("returns errors", func() {
+				Expect(parseErrs).To(HaveKey("invalid_file.yaml"))
+			})
+		})
+
+		PContext("with invalid YAMLs interleaved", func() {
+			BeforeEach(func() {
+				reference = "TODO"
+			})
+
+			It("returns the valid ones", func() {
+				Expect(objects).ToNot(BeEmpty())
+			})
+
+			It("returns errors", func() {
+				Expect(parseErrs).ToNot(BeEmpty())
+			})
+		})
+	})
 })

--- a/pkg/controller/gittrack/files_test.go
+++ b/pkg/controller/gittrack/files_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package gittrack
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+  gitstore "github.com/pusher/git-store"
+)
+
+var _ = Describe("GitTrack Suite", func() {
+	Describe("checkoutRepo", func() {
+		var r *ReconcileGitTrack
+		var mgr manager.Manager
+
+		var checkoutErr error
+		var repo *gitstore.Repo
+		var url string
+		var reference string
+		var credentials *gitCredentials
+
+		BeforeEach(func() {
+			// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
+			// channel when it is finished.
+			var err error
+			cfg.RateLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
+			mgr, err = manager.New(cfg, manager.Options{
+				MetricsBindAddress: "0", // Disable serving metrics while testing
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			recFn := newReconciler(mgr)
+			r = recFn.(*ReconcileGitTrack)
+
+			repo = nil
+			checkoutErr = nil
+			url = repositoryURL
+			reference = "master"
+			credentials = nil
+		})
+
+		JustBeforeEach(func() {
+			repo, checkoutErr = r.checkoutRepo(url, reference, credentials)
+		})
+
+		Context("when no credentials are provided or required", func() {
+			It("checks out the repository", func() {
+				Expect(repo).ToNot(BeNil())
+			})
+
+			It("does not return an error", func() {
+				Expect(checkoutErr).ToNot(HaveOccurred())
+			})
+		})
+  })
+})

--- a/pkg/controller/gittrack/gittrack_controller.go
+++ b/pkg/controller/gittrack/gittrack_controller.go
@@ -181,85 +181,6 @@ func (r *ReconcileGitTrack) withValues(keysAndValues ...interface{}) *ReconcileG
 	return &reconciler
 }
 
-// checkoutRepo checks out the repository at reference and returns a pointer to said repository
-func (r *ReconcileGitTrack) checkoutRepo(url string, ref string, gitCreds *gitCredentials) (*gitstore.Repo, error) {
-	r.log.V(1).Info("Getting repository", "url", url)
-	repoRef, err := createRepoRefFromCreds(url, gitCreds)
-	if err != nil {
-		return &gitstore.Repo{}, err
-	}
-	rc, done, err := r.store.GetAsync(repoRef)
-	if err != nil {
-		return &gitstore.Repo{}, fmt.Errorf("failed to get repository '%s': %v'", url, err)
-	}
-	repo := &gitstore.Repo{}
-
-	select {
-	case <-done:
-		if rc.Error != nil {
-			return repo, fmt.Errorf("failed to get repository '%s': %v'", url, rc.Error)
-		}
-		repo = rc.Repo
-	case <-time.After(farosflags.FetchTimeout):
-		return repo, fmt.Errorf("timed out getting repository '%s'", url)
-	}
-
-	r.log.V(1).Info("Checking out reference", "reference", ref)
-	ctx, cancel := context.WithTimeout(context.Background(), farosflags.FetchTimeout)
-	defer cancel()
-	err = repo.CheckoutContext(ctx, ref)
-	if err != nil {
-		return &gitstore.Repo{}, fmt.Errorf("failed to checkout '%s': %v", ref, err)
-	}
-
-	lastUpdated, err := repo.LastUpdated()
-	if err != nil {
-		return &gitstore.Repo{}, fmt.Errorf("failed to get last updated timestamp: %v", err)
-	}
-
-	r.mutex.Lock()
-	r.lastUpdateTimes[url] = lastUpdated
-	r.mutex.Unlock()
-
-	return repo, nil
-}
-
-// getFiles checks out the Spec.Repository at Spec.Reference and returns a map of filename to
-// gitstore.File pointers
-func (r *ReconcileGitTrack) getFiles(gt farosv1alpha1.GitTrackInterface) (map[string]*gitstore.File, error) {
-	r.recorder.Eventf(gt, apiv1.EventTypeNormal, "CheckoutStarted", "Checking out '%s' at '%s'", gt.GetSpec().Repository, gt.GetSpec().Reference)
-	gitCreds, err := r.fetchGitCredentials(gt)
-	if err != nil {
-		r.recorder.Eventf(gt, apiv1.EventTypeWarning, "CheckoutFailed", "Failed to checkout '%s' at '%s'", gt.GetSpec().Repository, gt.GetSpec().Reference)
-		return nil, fmt.Errorf("unable to retrieve git credentials from secret: %v", err)
-	}
-
-	repo, err := r.checkoutRepo(gt.GetSpec().Repository, gt.GetSpec().Reference, gitCreds)
-	if err != nil {
-		r.recorder.Eventf(gt, apiv1.EventTypeWarning, "CheckoutFailed", "Failed to checkout '%s' at '%s'", gt.GetSpec().Repository, gt.GetSpec().Reference)
-		return nil, err
-	}
-
-	subPath := gt.GetSpec().SubPath
-	if !strings.HasSuffix(subPath, "/") {
-		subPath += "/"
-	}
-
-	r.log.V(1).Info("Loading files from subpath", "subpath", subPath)
-	globbedSubPath := strings.TrimPrefix(subPath, "/") + "{**/*,*}.{yaml,yml,json}"
-	files, err := repo.GetAllFiles(globbedSubPath, true)
-	if err != nil {
-		r.recorder.Eventf(gt, apiv1.EventTypeWarning, "CheckoutFailed", "Failed to get files for SubPath '%s'", gt.GetSpec().SubPath)
-		return nil, fmt.Errorf("failed to get all files for subpath '%s': %v", gt.GetSpec().SubPath, err)
-	} else if len(files) == 0 {
-		r.recorder.Eventf(gt, apiv1.EventTypeWarning, "CheckoutFailed", "No files for SubPath '%s'", gt.GetSpec().SubPath)
-		return nil, fmt.Errorf("no files for subpath '%s'", gt.GetSpec().SubPath)
-	}
-
-	r.log.V(1).Info("Loaded files from repository", "file count", len(files))
-	return files, nil
-}
-
 // fetchInstance attempts to fetch the GitTrack resource by the name in the given Request
 func (r *ReconcileGitTrack) fetchInstance(req reconcile.Request) (farosv1alpha1.GitTrackInterface, error) {
 	var instance farosv1alpha1.GitTrackInterface
@@ -473,23 +394,6 @@ func (r *ReconcileGitTrack) deleteResources(leftovers map[string]farosv1alpha1.G
 		r.log.V(0).Info("Child deleted", "child name", name)
 	}
 	return nil
-}
-
-// objectsFrom iterates through all the files given and attempts to create Unstructured objects
-func objectsFrom(files map[string]*gitstore.File) ([]*unstructured.Unstructured, map[string]string) {
-	objects := []*unstructured.Unstructured{}
-	fileErrors := make(map[string]string)
-	for path, file := range files {
-		// TODO (@JoelSpeed): What happens if there are multiple resources in one file,
-		// but one of them is invalid? Can we still get the rest?
-		us, err := utils.YAMLToUnstructuredSlice([]byte(file.Contents()))
-		if err != nil {
-			fileErrors[path] = fmt.Sprintf("unable to parse '%s': %v\n", path, err)
-			continue
-		}
-		objects = append(objects, us...)
-	}
-	return objects, fileErrors
 }
 
 // checkOwner checks the owner reference of an object from the API to see if it

--- a/pkg/controller/gittrack/handler_test.go
+++ b/pkg/controller/gittrack/handler_test.go
@@ -241,6 +241,16 @@ var _ = Describe("Handler Suite", func() {
 			})
 		}
 
+		var AssertIgnoreInvalidFiles = func(numIgnored int) {
+			It("adds the file to `ignoredFiles`", func() {
+				Expect(result.ignoredFiles).To(HaveKeyWithValue("invalid_file.yaml", MatchRegexp("unable to parse 'invalid_file.yaml':")))
+			})
+
+			It("includes the invalid file in `ignored` count", func() {
+				Expect(result.ignored).To(BeNumerically("==", numIgnored))
+			})
+		}
+
 		var AssertMultiDocument = func() {
 			Context("for the daemonset in the file", func() {
 				BeforeEach(func() {
@@ -579,6 +589,14 @@ var _ = Describe("Handler Suite", func() {
 				AssertMultiDocument()
 			})
 
+			Context("with invalid files", func() {
+				BeforeEach(func() {
+					m.UpdateWithFunc(gt, setGitTrackReferenceFunc(repositoryURL, "936b7ee3df1dbd61b1fc691b742fa5d5d3c0dced"), timeout).Should(Succeed())
+				})
+
+				AssertIgnoreInvalidFiles(4)
+			})
+
 			Context("with a cluster scoped resource", func() {
 				BeforeEach(func() {
 					m.UpdateWithFunc(gt, setGitTrackReferenceFunc(repositoryURL, "b17c0e0f45beca3f1c1e62a7f49fecb738c60d42"), timeout).Should(Succeed())
@@ -684,6 +702,14 @@ var _ = Describe("Handler Suite", func() {
 				})
 
 				AssertMultiDocument()
+			})
+
+			Context("with invalid files", func() {
+				BeforeEach(func() {
+					m.UpdateWithFunc(gt, setGitTrackReferenceFunc(repositoryURL, "936b7ee3df1dbd61b1fc691b742fa5d5d3c0dced"), timeout).Should(Succeed())
+				})
+
+				AssertIgnoreInvalidFiles(1)
 			})
 
 			Context("with a cluster scoped resource", func() {


### PR DESCRIPTION
This PR ports most of the old files-related tests to the new format (and are now done for `ClusterGitTrack`s as well). There are some that are still pending being written, but the bulk is there.

I was planning on porting [this bunch](https://github.com/pusher/faros/blob/master/pkg/controller/gittrack/gittrack_controller_test.go#L277-L335) as well (the ones for invalid files are actually already included as of right now), although it won't really be the same as before as we're not testing the `Status` in the new handler suite, but I assume that this is intentional (cc @JoelSpeed)?

There's potentially still some cleaning up to do, but should be in a reviewable state.