### PR TITLE
Reset metrics registry in tests

### DIFF
--- a/pkg/controller/gittrack/gittrack_controller_suite_test.go
+++ b/pkg/controller/gittrack/gittrack_controller_suite_test.go
@@ -28,6 +28,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/pusher/faros/pkg/apis"
 	"github.com/pusher/faros/test/reporters"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -36,6 +37,7 @@ import (
 	"k8s.io/klog/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logr "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
@@ -90,6 +92,11 @@ var _ = BeforeSuite(func() {
 	if cfg, err = t.Start(); err != nil {
 		log.Fatal(err)
 	}
+})
+
+var _ = BeforeEach(func() {
+	// Reset metrics registry before each test
+	metrics.Registry = prometheus.NewRegistry()
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controller/gittrackobject/gittrackobject_controller_suite_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_suite_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/pusher/faros/pkg/apis"
 	farosflags "github.com/pusher/faros/pkg/flags"
 	"github.com/pusher/faros/test/reporters"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/klog/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logr "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
@@ -68,6 +70,11 @@ var _ = BeforeSuite(func() {
 	if cfg, err = t.Start(); err != nil {
 		log.Fatal(err)
 	}
+})
+
+var _ = BeforeEach(func() {
+	// Reset metrics registry before each test
+	metrics.Registry = prometheus.NewRegistry()
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
The test output is currently littered with error messages like:

```
E0918 10:35:59.384112   79407 workqueue.go:37] controller-runtime/metrics "msg"="failed to register metric" "error"="duplicate metrics collector registration attempted"  "name"="workqueue_retries_total" "queue"="gittrack-controller"
```

This gets rid of those messages.