### PR TITLE
implement not reconciling gittrackobjects

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -62,6 +62,12 @@ func main() {
 	flag.CommandLine.AddGoFlagSet(logFlags)
 	flag.Parse()
 
+	err = farosflags.ValidateSettings()
+	if err != nil {
+		log.Error(err, "Invalid flags set")
+		return
+	}
+
 	// Handle version flag
 	if *showVersion {
 		fmt.Printf("faros-gittrack-controller %s (built with %s)\n", VERSION, runtime.Version())

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -62,7 +62,7 @@ func main() {
 	flag.CommandLine.AddGoFlagSet(logFlags)
 	flag.Parse()
 
-	err = farosflags.ValidateSettings()
+	err = farosflags.ValidateFlags()
 	if err != nil {
 		log.Error(err, "Invalid flags set")
 		return

--- a/pkg/controller/gittrack/gittrack_controller.go
+++ b/pkg/controller/gittrack/gittrack_controller.go
@@ -97,6 +97,8 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, *reconcileGitTrac
 	return rec, opts
 }
 
+// reconcileGitTrackOpts is the mode that we're running the reconciler
+// in. Being able to change these options during runtime is helpful during tests.
 type reconcileGitTrackOpts struct {
 	clusterGitTrackMode farosflags.ClusterGitTrackMode
 	gitTrackMode        farosflags.GitTrackMode

--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -98,6 +98,8 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, *reconcileGitTrac
 	return rec, opts
 }
 
+// reconcileGitTrackOpts is the mode that we're running the reconciler
+// in. Being able to change these options during runtime is helpful during tests.
 type reconcileGitTrackObjectOpts struct {
 	clusterGitTrackMode farosflags.ClusterGitTrackMode
 	gitTrackMode        farosflags.GitTrackMode

--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	rlogr "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -112,7 +113,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler, opts *reconcileGitTrackObj
 	}
 
 	// Watch for changes to GitTrackObject
-	err = c.Watch(&source.Kind{Type: &farosv1alpha1.GitTrackObject{}}, &handler.EnqueueRequestForObject{})
+	predicate := []predicate.Predicate(nil)
+	if opts.clusterGitTrackMode == farosflags.CGTMExcludeNamespaced {
+		predicate = append(predicate, utils.NewOwnerIsNotClusterGitTrackPredicate(mgr.GetClient()))
+	}
+	if opts.gitTrackMode == farosflags.GTMDisabled {
+		predicate = append(predicate, utils.NewOwnerIsNotGitTrackPredicate(mgr.GetClient()))
+	}
+
+	err = c.Watch(&source.Kind{Type: &farosv1alpha1.GitTrackObject{}}, &handler.EnqueueRequestForObject{}, predicate...)
 	if err != nil {
 		return err
 	}
@@ -122,7 +131,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler, opts *reconcileGitTrackObj
 		err = c.Watch(
 			&source.Kind{Type: &farosv1alpha1.ClusterGitTrackObject{}},
 			&handler.EnqueueRequestForObject{},
-			utils.NewOwnerIsClusterGitTrackPredicate(mgr.GetClient()),
 		)
 		if err != nil {
 			return err

--- a/pkg/controller/gittrackobject/gittrackobject_controller.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller.go
@@ -122,7 +122,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, opts *reconcileGitTrackObj
 		err = c.Watch(
 			&source.Kind{Type: &farosv1alpha1.ClusterGitTrackObject{}},
 			&handler.EnqueueRequestForObject{},
-			utils.NewOwnerInNamespacePredicate(mgr.GetClient()),
+			utils.NewOwnerIsClusterGitTrackPredicate(mgr.GetClient()),
 		)
 		if err != nil {
 			return err
@@ -148,7 +148,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, opts *reconcileGitTrackObj
 				},
 				Log: rlogr.Log.WithName("gittrackobject-controller/enqueue-request-for-owner"),
 			},
-			utils.NewOwnersOwnerInNamespacePredicate(mgr.GetClient()),
+			utils.NewOurResponsibilityPredicate(mgr.GetClient(), opts.gitTrackMode, opts.clusterGitTrackMode),
 		)
 		if err != nil {
 			msg := fmt.Sprintf("unable to watch channel: %v", err)

--- a/pkg/controller/gittrackobject/gittrackobject_controller_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_test.go
@@ -162,9 +162,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 
 			BeforeEach(func() {
 				SetupTest(farosflags.GTMEnabled, farosflags.CGTMIncludeNamespaced)
-			})
 
-			BeforeEach(func() {
 				gto = testutils.ExampleGitTrackObject.DeepCopy()
 				gto.SetOwnerReferences([]metav1.OwnerReference{
 					{
@@ -542,8 +540,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 			Context("and ClusterGitTrackMode is set to Disabled", func() {
 				BeforeEach(func() {
 					SetupTest(farosflags.GTMEnabled, farosflags.CGTMDisabled)
-				})
-				BeforeEach(func() {
+
 					gto = testutils.ExampleClusterGitTrackObject.DeepCopy()
 					gto.SetOwnerReferences([]metav1.OwnerReference{
 						{
@@ -583,8 +580,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 
 				BeforeEach(func() {
 					SetupTest(farosflags.GTMEnabled, farosflags.CGTMExcludeNamespaced)
-				})
-				BeforeEach(func() {
+
 					gto = testutils.ExampleGitTrackObject.DeepCopy()
 					gto.SetOwnerReferences([]metav1.OwnerReference{
 						{
@@ -648,8 +644,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 
 				BeforeEach(func() {
 					SetupTest(farosflags.GTMDisabled, farosflags.CGTMIncludeNamespaced)
-				})
-				BeforeEach(func() {
+
 					gto = testutils.ExampleGitTrackObject.DeepCopy()
 					gto.SetOwnerReferences([]metav1.OwnerReference{
 						{
@@ -682,9 +677,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 			Context("and ClusterGitTrackMode set to IncludeNamespaced", func() {
 				BeforeEach(func() {
 					SetupTest(farosflags.GTMEnabled, farosflags.CGTMIncludeNamespaced)
-				})
 
-				BeforeEach(func() {
 					gto = testutils.ExampleClusterGitTrackObject.DeepCopy()
 					gto.SetOwnerReferences([]metav1.OwnerReference{
 						{

--- a/pkg/controller/gittrackobject/gittrackobject_controller_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_test.go
@@ -923,7 +923,9 @@ var _ = Describe("GitTrackObject Suite", func() {
 					})
 				})
 
-				Context("with an owner in a different namespace", func() {
+				// don't run these tests, since the cross-namespace ownership reference is
+				// invalid k8s.
+				PContext("with an owner in a different namespace", func() {
 					var ns *corev1.Namespace
 
 					BeforeEach(func() {

--- a/pkg/controller/gittrackobject/gittrackobject_controller_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_test.go
@@ -552,7 +552,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 					})
 					child = testutils.ExampleClusterRoleBinding.DeepCopy()
 					Expect(testutils.SetGitTrackObjectInterfaceSpec(gto, child)).To(Succeed())
-					m.Update(child).Should(Succeed())
+					m.Create(child).Should(Succeed())
 					// get the most recent version so we can get the UID
 					m.Get(child, timeout).Should(Succeed())
 					originalUID = child.GetUID()

--- a/pkg/controller/gittrackobject/gittrackobject_controller_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_test.go
@@ -597,7 +597,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 					namespacedChild = testutils.ExampleDeployment.DeepCopy()
 					Expect(testutils.SetGitTrackObjectInterfaceSpec(gto, namespacedChild)).To(Succeed())
 					m.Create(namespacedChild).Should(Succeed())
-					// get the most recent version so we can get the UID
+					// get the most recent version so we can get the UID and version
 					m.Get(namespacedChild, timeout).Should(Succeed())
 					originalUID = namespacedChild.GetUID()
 					originalVersion = namespacedChild.GetResourceVersion()

--- a/pkg/controller/gittrackobject/gittrackobject_controller_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_test.go
@@ -983,52 +983,6 @@ var _ = Describe("GitTrackObject Suite", func() {
 						})
 					})
 				})
-
-				// don't run these tests, since the cross-namespace ownership reference is
-				// invalid k8s.
-				PContext("with an owner in a different namespace", func() {
-					var ns *corev1.Namespace
-
-					BeforeEach(func() {
-						ns = &corev1.Namespace{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "not-default",
-							},
-						}
-						m.Create(ns)
-
-						gitTrack = &farosv1alpha1.GitTrack{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "testgittrack",
-								Namespace: "not-default",
-							},
-							Spec: farosv1alpha1.GitTrackSpec{
-								Reference:  "foo",
-								Repository: "bar",
-							},
-						}
-						m.Create(gitTrack).Should(Succeed())
-
-						gto.SetOwnerReferences([]metav1.OwnerReference{
-							{
-								APIVersion: "faros.pusher.com/v1alpha1",
-								Kind:       "GitTrack",
-								UID:        gitTrack.UID,
-								Name:       gitTrack.Name,
-							},
-						})
-						m.Create(gto).Should(Succeed())
-					})
-
-					AfterEach(func() {
-						m.Delete(gitTrack).Should(Succeed())
-						m.Get(gitTrack, timeout).ShouldNot(Succeed())
-					})
-
-					It("should not be reconciled", func() {
-						Consistently(requests, consistentlyTimeout).ShouldNot(Receive(Equal(expectedClusterRequest)))
-					})
-				})
 			})
 		})
 	})

--- a/pkg/controller/gittrackobject/gittrackobject_controller_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_test.go
@@ -559,6 +559,9 @@ var _ = Describe("GitTrackObject Suite", func() {
 					// get the most recent version so we can get the UID
 					m.Get(child, timeout).Should(Succeed())
 					originalUID = child.GetUID()
+
+					// Create
+					m.Create(gto).Should(Succeed())
 				})
 
 				It("should not get reconcile ClusterGitTrackObjects", func() {
@@ -598,6 +601,9 @@ var _ = Describe("GitTrackObject Suite", func() {
 					m.Get(namespacedChild, timeout).Should(Succeed())
 					originalUID = namespacedChild.GetUID()
 					originalVersion = namespacedChild.GetResourceVersion()
+
+					// Create
+					m.Create(gto).Should(Succeed())
 				})
 
 				It("should not get reconcile namespaced GitTrackObjects owned by ClusterGitTracks", func() {

--- a/pkg/controller/gittrackobject/gittrackobject_controller_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_test.go
@@ -564,7 +564,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 					m.Create(gto).Should(Succeed())
 				})
 
-				It("should not get reconcile ClusterGitTrackObjects", func() {
+				It("should not reconcile ClusterGitTrackObjects", func() {
 					Consistently(requests, consistentlyTimeout).ShouldNot(Receive(Equal(expectedClusterRequest)))
 				})
 				It("should not update the child", func() {
@@ -609,7 +609,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 						m.Create(gto).Should(Succeed())
 					})
 
-					It("should not get reconcile namespaced GitTrackObjects", func() {
+					It("should not reconcile namespaced GitTrackObjects", func() {
 						Consistently(requests, consistentlyTimeout).ShouldNot(Receive(Equal(expectedRequest)))
 					})
 					It("should not update the child", func() {

--- a/pkg/controller/gittrackobject/gittrackobject_controller_test.go
+++ b/pkg/controller/gittrackobject/gittrackobject_controller_test.go
@@ -564,6 +564,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 				It("should not reconcile ClusterGitTrackObjects", func() {
 					Consistently(requests, consistentlyTimeout).ShouldNot(Receive(Equal(expectedClusterRequest)))
 				})
+
 				It("should not update the child", func() {
 					m.Consistently(child, consistentlyTimeout).ShouldNot(testutils.WithSubjects(BeEmpty()))
 				})
@@ -608,6 +609,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 					It("should not reconcile namespaced GitTrackObjects", func() {
 						Consistently(requests, consistentlyTimeout).ShouldNot(Receive(Equal(expectedRequest)))
 					})
+
 					It("should not update the child", func() {
 						m.Consistently(namespacedChild, timeout).Should(testutils.WithResourceVersion(Equal(originalVersion)))
 					})
@@ -626,6 +628,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 					It("should not reconcile GitTrackObject", func() {
 						Consistently(requests, consistentlyTimeout).ShouldNot(Receive(Equal(expectedRequest)))
 					})
+
 					It("should not update the child", func() {
 						m.Consistently(namespacedChild, consistentlyTimeout).Should(testutils.WithResourceVersion(Equal(originalVersion)))
 					})
@@ -669,6 +672,7 @@ var _ = Describe("GitTrackObject Suite", func() {
 				It("should reconcile namespaced GitTrackObjects owned by ClusterGitTracks", func() {
 					Eventually(requests, timeout).Should(Receive(Equal(expectedRequest)))
 				})
+
 				It("should update the child", func() {
 					m.Eventually(namespacedChild, timeout).ShouldNot(testutils.WithResourceVersion(Equal(originalVersion)))
 				})

--- a/pkg/controller/gittrackobject/handler_test.go
+++ b/pkg/controller/gittrackobject/handler_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Handler Suite", func() {
 
 		m = testutils.Matcher{Client: c, FarosClient: applier}
 
-		recFn := newReconciler(mgr)
+		recFn, _ := newReconciler(mgr)
 		r = recFn.(*ReconcileGitTrackObject)
 
 		stopInformers = r.StopChan()

--- a/pkg/controller/gittrackobject/metrics_test.go
+++ b/pkg/controller/gittrackobject/metrics_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Metrics Suite", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		recFn := newReconciler(mgr)
+		recFn, _ := newReconciler(mgr)
 		r = recFn.(*ReconcileGitTrackObject)
 
 		// Reset all metrics before each test

--- a/pkg/controller/gittrackobject/status_test.go
+++ b/pkg/controller/gittrackobject/status_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Status Suite", func() {
 
 		m = testutils.Matcher{Client: mgr.GetClient()}
 
-		recFn := newReconciler(mgr)
+		recFn, _ := newReconciler(mgr)
 		r = recFn.(*ReconcileGitTrackObject)
 
 		stopInformers = r.StopChan()

--- a/pkg/controller/gittrackobject/watch_test.go
+++ b/pkg/controller/gittrackobject/watch_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Watch Suite", func() {
 		c = mgr.GetClient()
 		m = testutils.Matcher{Client: c}
 
-		recFn := newReconciler(mgr)
+		recFn, _ := newReconciler(mgr)
 		r = recFn.(*ReconcileGitTrackObject)
 
 		stopInformers = r.StopChan()

--- a/pkg/flags/flagset.go
+++ b/pkg/flags/flagset.go
@@ -87,6 +87,19 @@ func ParseIgnoredResources() (map[schema.GroupVersionResource]interface{}, error
 	return gvrs, nil
 }
 
+// ValidateSettings returns an error if an invalid set of options have been set in the flags.
+// It must be called after the flags have been parsed
+func ValidateSettings() error {
+	if !FlagSet.Parsed() {
+		return fmt.Errorf("ValidateSettings called on unparsed flags")
+	}
+
+	if GitTrack == GTMEnabled && Namespace != "" && ClusterGitTrack == CGTMIncludeNamespaced {
+		return fmt.Errorf("Cannot use gittrack-mode enabled with namespace %q and clustergittrack-mode set to IncludeNamespaced", Namespace)
+	}
+	return nil
+}
+
 // ClusterGitTrackMode specifies which mode we're running ClusterGitTracks in
 type ClusterGitTrackMode int
 

--- a/pkg/flags/flagset.go
+++ b/pkg/flags/flagset.go
@@ -87,11 +87,11 @@ func ParseIgnoredResources() (map[schema.GroupVersionResource]interface{}, error
 	return gvrs, nil
 }
 
-// ValidateSettings returns an error if an invalid set of options have been set in the flags.
+// ValidateFlags returns an error if an invalid set of options have been set in the flags.
 // It must be called after the flags have been parsed
-func ValidateSettings() error {
+func ValidateFlags() error {
 	if !FlagSet.Parsed() {
-		return fmt.Errorf("ValidateSettings called on unparsed flags")
+		return fmt.Errorf("ValidateFlags called on unparsed flags")
 	}
 
 	if GitTrack == GTMEnabled && Namespace != "" && ClusterGitTrack == CGTMIncludeNamespaced {

--- a/pkg/flags/flagset.go
+++ b/pkg/flags/flagset.go
@@ -90,7 +90,7 @@ func ParseIgnoredResources() (map[schema.GroupVersionResource]interface{}, error
 // ValidateFlags returns an error if an invalid set of options have been set in the flags.
 // It must be called after the flags have been parsed
 func ValidateFlags() error {
-	if !FlagSet.Parsed() {
+	if !flag.Parsed() {
 		return fmt.Errorf("ValidateFlags called on unparsed flags")
 	}
 

--- a/pkg/utils/predicate.go
+++ b/pkg/utils/predicate.go
@@ -136,7 +136,7 @@ func (p OurResponsibilityPredicate) isOurResponsibility(ownerRefs []metav1.Owner
 	gtoList := &farosv1alpha1.GitTrackObjectList{}
 	err := p.client.List(context.TODO(), gtoList)
 	if err != nil {
-		// We can't list GTs so fail closed and ignore the requests
+		// We can't list GTOs so fail closed and ignore the requests
 		return false
 	}
 

--- a/pkg/utils/predicate.go
+++ b/pkg/utils/predicate.go
@@ -168,7 +168,7 @@ func (p OwnerIsGitTrackPredicate) ownerIsGitTrack(ownerRefs []metav1.OwnerRefere
 	return false
 }
 
-// OwnersOwnerIsGitTrackPredicate filters events to check the owner of the event
+// OwnersOwnerIsGitTrackPredicate filters events to check the owner's owner of the event
 // object is a GitTrack
 type OwnersOwnerIsGitTrackPredicate struct {
 	client client.Client
@@ -181,22 +181,22 @@ func NewOwnersOwnerIsGitTrackPredicate(client client.Client) OwnersOwnerIsGitTra
 	}
 }
 
-// Create returns true if the event object owner is a GitTrack
+// Create returns true if the event object owner's owner is a GitTrack
 func (p OwnersOwnerIsGitTrackPredicate) Create(e event.CreateEvent) bool {
 	return p.ownersOwnerIsGitTrack(e.Meta.GetOwnerReferences())
 }
 
-// Update returns true if the event object owner is a GitTrack
+// Update returns true if the event object owner's owner is a GitTrack
 func (p OwnersOwnerIsGitTrackPredicate) Update(e event.UpdateEvent) bool {
 	return p.ownersOwnerIsGitTrack(e.MetaNew.GetOwnerReferences())
 }
 
-// Delete returns true if the event object owner is a GitTrack
+// Delete returns true if the event object owner's owner is a GitTrack
 func (p OwnersOwnerIsGitTrackPredicate) Delete(e event.DeleteEvent) bool {
 	return p.ownersOwnerIsGitTrack(e.Meta.GetOwnerReferences())
 }
 
-// Generic returns true if the event object owner is a GitTrack
+// Generic returns true if the event object owner's owner is a GitTrack
 func (p OwnersOwnerIsGitTrackPredicate) Generic(e event.GenericEvent) bool {
 	return p.ownersOwnerIsGitTrack(e.Meta.GetOwnerReferences())
 }
@@ -241,7 +241,7 @@ func (p OwnersOwnerIsGitTrackPredicate) ownersOwnerIsGitTrack(ownerRefs []metav1
 	return false
 }
 
-// OwnersOwnerIsClusterGitTrackPredicate filters events to check the owner of the event
+// OwnersOwnerIsClusterGitTrackPredicate filters events to check the owner's owner of the event
 // object is a ClusterGitTrack
 type OwnersOwnerIsClusterGitTrackPredicate struct {
 	client            client.Client
@@ -256,22 +256,22 @@ func NewOwnersOwnerIsClusterGitTrackPredicate(client client.Client, includeNames
 	}
 }
 
-// Create returns true if the event object owner is a ClusterGitTrack
+// Create returns true if the event object owner's owner is a ClusterGitTrack
 func (p OwnersOwnerIsClusterGitTrackPredicate) Create(e event.CreateEvent) bool {
 	return p.ownersOwnerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
-// Update returns true if the event object owner is a ClusterGitTrack
+// Update returns true if the event object owner's owner is a ClusterGitTrack
 func (p OwnersOwnerIsClusterGitTrackPredicate) Update(e event.UpdateEvent) bool {
 	return p.ownersOwnerIsClusterGitTrack(e.MetaNew.GetOwnerReferences())
 }
 
-// Delete returns true if the event object owner is a ClusterGitTrack
+// Delete returns true if the event object owner's owner is a ClusterGitTrack
 func (p OwnersOwnerIsClusterGitTrackPredicate) Delete(e event.DeleteEvent) bool {
 	return p.ownersOwnerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
-// Generic returns true if the event object owner is a ClusterGitTrack
+// Generic returns true if the event object owner's owner is a ClusterGitTrack
 func (p OwnersOwnerIsClusterGitTrackPredicate) Generic(e event.GenericEvent) bool {
 	return p.ownersOwnerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }

--- a/pkg/utils/predicate.go
+++ b/pkg/utils/predicate.go
@@ -165,46 +165,88 @@ func NewOwnersOwnerInNamespacePredicate(client client.Client) OwnersOwnerInNames
 	}
 }
 
-// OwnerIsClusterGitTrackPredicate filters events to check the owner of the event
+// OwnerIsNotClusterGitTrackPredicate filters events to check the owner of the event
 // object is a ClusterGitTrack
-type OwnerIsClusterGitTrackPredicate struct {
+type OwnerIsNotClusterGitTrackPredicate struct {
 	client client.Client
 }
 
-// NewOwnerIsClusterGitTrackPredicate constructs a new OwnerIsClusterGitTrackPredicate
-func NewOwnerIsClusterGitTrackPredicate(client client.Client) OwnerIsClusterGitTrackPredicate {
-	return OwnerIsClusterGitTrackPredicate{
+// NewOwnerIsNotClusterGitTrackPredicate constructs a new OwnerIsNotClusterGitTrackPredicate
+func NewOwnerIsNotClusterGitTrackPredicate(client client.Client) OwnerIsNotClusterGitTrackPredicate {
+	return OwnerIsNotClusterGitTrackPredicate{
 		client: client,
 	}
 }
 
 // Create returns true if the event object owner is a ClusterGitTrack
-func (p OwnerIsClusterGitTrackPredicate) Create(e event.CreateEvent) bool {
+func (p OwnerIsNotClusterGitTrackPredicate) Create(e event.CreateEvent) bool {
 	return p.ownerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
 // Update returns true if the event object owner is a ClusterGitTrack
-func (p OwnerIsClusterGitTrackPredicate) Update(e event.UpdateEvent) bool {
+func (p OwnerIsNotClusterGitTrackPredicate) Update(e event.UpdateEvent) bool {
 	return p.ownerIsClusterGitTrack(e.MetaNew.GetOwnerReferences())
 }
 
 // Delete returns true if the event object owner is a ClusterGitTrack
-func (p OwnerIsClusterGitTrackPredicate) Delete(e event.DeleteEvent) bool {
+func (p OwnerIsNotClusterGitTrackPredicate) Delete(e event.DeleteEvent) bool {
 	return p.ownerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
 // Generic returns true if the event object owner is a ClusterGitTrack
-func (p OwnerIsClusterGitTrackPredicate) Generic(e event.GenericEvent) bool {
+func (p OwnerIsNotClusterGitTrackPredicate) Generic(e event.GenericEvent) bool {
 	return p.ownerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
-func (p OwnerIsClusterGitTrackPredicate) ownerIsClusterGitTrack(ownerRefs []metav1.OwnerReference) bool {
+func (p OwnerIsNotClusterGitTrackPredicate) ownerIsClusterGitTrack(ownerRefs []metav1.OwnerReference) bool {
 	for _, ref := range ownerRefs {
 		if ref.Kind == "ClusterGitTrack" && ref.APIVersion == farosGroupVersion {
-			return true
+			return false
 		}
 	}
-	return false
+	return true
+}
+
+// OwnerIsNotGitTrackPredicate filters events to check the owner of the event
+// object is a GitTrack
+type OwnerIsNotGitTrackPredicate struct {
+	client client.Client
+}
+
+// NewOwnerIsNotGitTrackPredicate constructs a new OwnerIsNotGitTrackPredicate
+func NewOwnerIsNotGitTrackPredicate(client client.Client) OwnerIsNotGitTrackPredicate {
+	return OwnerIsNotGitTrackPredicate{
+		client: client,
+	}
+}
+
+// Create returns true if the event object owner is a GitTrack
+func (p OwnerIsNotGitTrackPredicate) Create(e event.CreateEvent) bool {
+	return p.ownerIsGitTrack(e.Meta.GetOwnerReferences())
+}
+
+// Update returns true if the event object owner is a GitTrack
+func (p OwnerIsNotGitTrackPredicate) Update(e event.UpdateEvent) bool {
+	return p.ownerIsGitTrack(e.MetaNew.GetOwnerReferences())
+}
+
+// Delete returns true if the event object owner is a GitTrack
+func (p OwnerIsNotGitTrackPredicate) Delete(e event.DeleteEvent) bool {
+	return p.ownerIsGitTrack(e.Meta.GetOwnerReferences())
+}
+
+// Generic returns true if the event object owner is a GitTrack
+func (p OwnerIsNotGitTrackPredicate) Generic(e event.GenericEvent) bool {
+	return p.ownerIsGitTrack(e.Meta.GetOwnerReferences())
+}
+
+func (p OwnerIsNotGitTrackPredicate) ownerIsGitTrack(ownerRefs []metav1.OwnerReference) bool {
+	for _, ref := range ownerRefs {
+		if ref.Kind == "GitTrack" && ref.APIVersion == farosGroupVersion {
+			return false
+		}
+	}
+	return true
 }
 
 type OurResponsibilityPredicate struct {

--- a/pkg/utils/predicate.go
+++ b/pkg/utils/predicate.go
@@ -251,13 +251,18 @@ func (p OurResponsibilityPredicate) isOurResponsibility(ownerRefs []metav1.Owner
 			// is invalid. Check if we need to be more proactive about invalid states
 			gto, inSet := gtoSet[ref.UID]
 			if p.gitTrackMode == farosflags.GTMEnabled && inSet {
-				return true
+				// make sure that we're owned by a gittrack and not a clustergittrack
+				for _, gtref := range gto.GetOwnerReferences() {
+					if gtref.APIVersion == farosGroupVersion && gtref.Kind == "GitTrack" {
+						return true
+					}
+				}
 			}
 
 			// a ClusterGitTrack might have created this GitTrackObject
 			if inSet && p.clusterGitTrackMode == farosflags.CGTMIncludeNamespaced {
 				for _, gtref := range gto.GetOwnerReferences() {
-					if gtref.APIVersion == farosGroupVersion && ref.Kind == "ClusterGitTrack" {
+					if gtref.APIVersion == farosGroupVersion && gtref.Kind == "ClusterGitTrack" {
 						return true
 					}
 				}

--- a/pkg/utils/predicate.go
+++ b/pkg/utils/predicate.go
@@ -294,6 +294,8 @@ func (p OwnersOwnerIsClusterGitTrackPredicate) ownersOwnerIsClusterGitTrack(owne
 		if ref.APIVersion != farosGroupVersion {
 			continue
 		}
+		// ClusterGitTrackObjects can only be owned by ClusterGitTracks, so we
+		// if we're owned by a CGTO, then we know that our owners owner is a ClusterGitTrack
 		if ref.Kind == "ClusterGitTrackObject" {
 			return true
 		}

--- a/pkg/utils/predicate.go
+++ b/pkg/utils/predicate.go
@@ -31,140 +31,6 @@ const (
 	farosGroupVersion = "faros.pusher.com/v1alpha1"
 )
 
-// OwnerInNamespacePredicate filters events to check the owner of the event
-// object is in the controller's namespace
-type OwnerInNamespacePredicate struct {
-	client client.Client
-}
-
-// Create returns true if the event object's owner is in the same namespace
-func (p OwnerInNamespacePredicate) Create(e event.CreateEvent) bool {
-	return p.ownerInNamespace(e.Meta.GetOwnerReferences())
-}
-
-// Update returns true if the event object's owner is in the same namespace
-func (p OwnerInNamespacePredicate) Update(e event.UpdateEvent) bool {
-	return p.ownerInNamespace(e.MetaNew.GetOwnerReferences())
-}
-
-// Delete returns true if the event object's owner is in the same namespace
-func (p OwnerInNamespacePredicate) Delete(e event.DeleteEvent) bool {
-	return p.ownerInNamespace(e.Meta.GetOwnerReferences())
-}
-
-// Generic returns true if the event object's owner is in the same namespace
-func (p OwnerInNamespacePredicate) Generic(e event.GenericEvent) bool {
-	return p.ownerInNamespace(e.Meta.GetOwnerReferences())
-}
-
-// ownerInNamespace returns true if the the GitTrack owner is in the namespace
-// managed by the controller
-//
-// This works on the premise that listing objects from the client will only
-// return those in its cache.
-// When it is restricted to a namespace this should only be the GitTracks
-// in the namespace the controller is managing.
-func (p OwnerInNamespacePredicate) ownerInNamespace(ownerRefs []metav1.OwnerReference) bool {
-	gtList := &farosv1alpha1.GitTrackList{}
-	err := p.client.List(context.TODO(), gtList)
-	if err != nil {
-		// We can't list CGTOs so fail closed and ignore the requests
-		return false
-	}
-	for _, ref := range ownerRefs {
-		if ref.Kind == "GitTrack" && ref.APIVersion == farosGroupVersion {
-			for _, gt := range gtList.Items {
-				if ref.UID == gt.UID {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
-// NewOwnerInNamespacePredicate constructs a new OwnerInNamespacePredicate
-func NewOwnerInNamespacePredicate(client client.Client) OwnerInNamespacePredicate {
-	return OwnerInNamespacePredicate{
-		client: client,
-	}
-}
-
-// OwnersOwnerInNamespacePredicate filters events to check the owners owner of
-// the event object is in the controller's namespace
-type OwnersOwnerInNamespacePredicate struct {
-	client                    client.Client
-	ownerInNamespacePredicate OwnerInNamespacePredicate
-}
-
-// Create returns true if the event object owners owner is in the same namespace
-func (p OwnersOwnerInNamespacePredicate) Create(e event.CreateEvent) bool {
-	return p.ownersOwnerInNamespace(e.Meta.GetOwnerReferences())
-}
-
-// Update returns true if the event object owners owner is in the same namespace
-func (p OwnersOwnerInNamespacePredicate) Update(e event.UpdateEvent) bool {
-	return p.ownersOwnerInNamespace(e.MetaNew.GetOwnerReferences())
-}
-
-// Delete returns true if the event object owners owner is in the same namespace
-func (p OwnersOwnerInNamespacePredicate) Delete(e event.DeleteEvent) bool {
-	return p.ownersOwnerInNamespace(e.Meta.GetOwnerReferences())
-}
-
-// Generic returns true if the event object owners owner is in the same namespace
-func (p OwnersOwnerInNamespacePredicate) Generic(e event.GenericEvent) bool {
-	return p.ownersOwnerInNamespace(e.Meta.GetOwnerReferences())
-}
-
-// ownersOwnerInNamespace returns true if the the GitTrackObject's GitTrack
-// owner of the event object is in the namespace  managed by the controller
-//
-// This works on the premise that listing objects from the client will only
-// return those in its cache.
-// When it is restricted to a namespace this should only be the GitTracks
-// in the namespace the controller is managing.
-func (p OwnersOwnerInNamespacePredicate) ownersOwnerInNamespace(ownerRefs []metav1.OwnerReference) bool {
-	cgtoList := &farosv1alpha1.ClusterGitTrackObjectList{}
-	err := p.client.List(context.TODO(), cgtoList)
-	if err != nil {
-		// We can't list CGTOs so fail closed and ignore the requests
-		return false
-	}
-	gtoList := &farosv1alpha1.GitTrackObjectList{}
-	err = p.client.List(context.TODO(), gtoList)
-	if err != nil {
-		// We can't list GTOs so fail closed and ignore the requests
-		return false
-	}
-
-	for _, ref := range ownerRefs {
-		if ref.Kind == "GitTrackObject" && ref.APIVersion == farosGroupVersion {
-			for _, gto := range gtoList.Items {
-				if ref.UID == gto.UID {
-					return p.ownerInNamespacePredicate.ownerInNamespace(gto.GetOwnerReferences())
-				}
-			}
-		}
-		if ref.Kind == "ClusterGitTrackObject" && ref.APIVersion == farosGroupVersion {
-			for _, cgto := range cgtoList.Items {
-				if ref.UID == cgto.UID {
-					return p.ownerInNamespacePredicate.ownerInNamespace(cgto.GetOwnerReferences())
-				}
-			}
-		}
-	}
-	return false
-}
-
-// NewOwnersOwnerInNamespacePredicate constructs a new OwnersOwnerInNamespacePredicate
-func NewOwnersOwnerInNamespacePredicate(client client.Client) OwnersOwnerInNamespacePredicate {
-	return OwnersOwnerInNamespacePredicate{
-		client:                    client,
-		ownerInNamespacePredicate: NewOwnerInNamespacePredicate(client),
-	}
-}
-
 // OwnerIsNotClusterGitTrackPredicate filters events to check the owner of the event
 // object is a ClusterGitTrack
 type OwnerIsNotClusterGitTrackPredicate struct {
@@ -249,12 +115,15 @@ func (p OwnerIsNotGitTrackPredicate) ownerIsGitTrack(ownerRefs []metav1.OwnerRef
 	return true
 }
 
+// OurResponsibilityPredicate returns whether an event is our
+// responsibility, based on the flags we're running with
 type OurResponsibilityPredicate struct {
 	client              client.Client
 	gitTrackMode        farosflags.GitTrackMode
 	clusterGitTrackMode farosflags.ClusterGitTrackMode
 }
 
+// NewOurResponsibilityPredicate constructs a new OurResponsibilityPredicate
 func NewOurResponsibilityPredicate(client client.Client, gtmode farosflags.GitTrackMode, cgtmode farosflags.ClusterGitTrackMode) OurResponsibilityPredicate {
 	return OurResponsibilityPredicate{
 		client:              client,

--- a/pkg/utils/predicate.go
+++ b/pkg/utils/predicate.go
@@ -37,7 +37,7 @@ type OwnerIsClusterGitTrackPredicate struct {
 	client client.Client
 }
 
-// NewOwnerIsNotClusterGitTrackPredicate constructs a new OwnerIsNotClusterGitTrackPredicate
+// NewOwnerIsClusterGitTrackPredicate constructs a new OwnerIsClusterGitTrackPredicate
 func NewOwnerIsClusterGitTrackPredicate(client client.Client) OwnerIsClusterGitTrackPredicate {
 	return OwnerIsClusterGitTrackPredicate{
 		client: client,
@@ -79,7 +79,7 @@ type OwnerIsGitTrackPredicate struct {
 	client client.Client
 }
 
-// NewOwnerIsNotGitTrackPredicate constructs a new OwnerIsNotGitTrackPredicate
+// NewOwnerIsGitTrackPredicate constructs a new OwnerIsGitTrackPredicate
 func NewOwnerIsGitTrackPredicate(client client.Client) OwnerIsGitTrackPredicate {
 	return OwnerIsGitTrackPredicate{
 		client: client,

--- a/pkg/utils/predicate.go
+++ b/pkg/utils/predicate.go
@@ -31,88 +31,88 @@ const (
 	farosGroupVersion = "faros.pusher.com/v1alpha1"
 )
 
-// OwnerIsNotClusterGitTrackPredicate filters events to check the owner of the event
+// OwnerIsClusterGitTrackPredicate filters events to check the owner of the event
 // object is a ClusterGitTrack
-type OwnerIsNotClusterGitTrackPredicate struct {
+type OwnerIsClusterGitTrackPredicate struct {
 	client client.Client
 }
 
 // NewOwnerIsNotClusterGitTrackPredicate constructs a new OwnerIsNotClusterGitTrackPredicate
-func NewOwnerIsNotClusterGitTrackPredicate(client client.Client) OwnerIsNotClusterGitTrackPredicate {
-	return OwnerIsNotClusterGitTrackPredicate{
+func NewOwnerIsClusterGitTrackPredicate(client client.Client) OwnerIsClusterGitTrackPredicate {
+	return OwnerIsClusterGitTrackPredicate{
 		client: client,
 	}
 }
 
 // Create returns true if the event object owner is a ClusterGitTrack
-func (p OwnerIsNotClusterGitTrackPredicate) Create(e event.CreateEvent) bool {
-	return p.ownerIsNotClusterGitTrack(e.Meta.GetOwnerReferences())
+func (p OwnerIsClusterGitTrackPredicate) Create(e event.CreateEvent) bool {
+	return p.ownerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
 // Update returns true if the event object owner is a ClusterGitTrack
-func (p OwnerIsNotClusterGitTrackPredicate) Update(e event.UpdateEvent) bool {
-	return p.ownerIsNotClusterGitTrack(e.MetaNew.GetOwnerReferences())
+func (p OwnerIsClusterGitTrackPredicate) Update(e event.UpdateEvent) bool {
+	return p.ownerIsClusterGitTrack(e.MetaNew.GetOwnerReferences())
 }
 
 // Delete returns true if the event object owner is a ClusterGitTrack
-func (p OwnerIsNotClusterGitTrackPredicate) Delete(e event.DeleteEvent) bool {
-	return p.ownerIsNotClusterGitTrack(e.Meta.GetOwnerReferences())
+func (p OwnerIsClusterGitTrackPredicate) Delete(e event.DeleteEvent) bool {
+	return p.ownerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
 // Generic returns true if the event object owner is a ClusterGitTrack
-func (p OwnerIsNotClusterGitTrackPredicate) Generic(e event.GenericEvent) bool {
-	return p.ownerIsNotClusterGitTrack(e.Meta.GetOwnerReferences())
+func (p OwnerIsClusterGitTrackPredicate) Generic(e event.GenericEvent) bool {
+	return p.ownerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
-func (p OwnerIsNotClusterGitTrackPredicate) ownerIsNotClusterGitTrack(ownerRefs []metav1.OwnerReference) bool {
+func (p OwnerIsClusterGitTrackPredicate) ownerIsClusterGitTrack(ownerRefs []metav1.OwnerReference) bool {
 	for _, ref := range ownerRefs {
 		if ref.Kind == "ClusterGitTrack" && ref.APIVersion == farosGroupVersion {
-			return false
+			return true
 		}
 	}
-	return true
+	return false
 }
 
-// OwnerIsNotGitTrackPredicate filters events to check the owner of the event
+// OwnerIsGitTrackPredicate filters events to check the owner of the event
 // object is a GitTrack
-type OwnerIsNotGitTrackPredicate struct {
+type OwnerIsGitTrackPredicate struct {
 	client client.Client
 }
 
 // NewOwnerIsNotGitTrackPredicate constructs a new OwnerIsNotGitTrackPredicate
-func NewOwnerIsNotGitTrackPredicate(client client.Client) OwnerIsNotGitTrackPredicate {
-	return OwnerIsNotGitTrackPredicate{
+func NewOwnerIsGitTrackPredicate(client client.Client) OwnerIsGitTrackPredicate {
+	return OwnerIsGitTrackPredicate{
 		client: client,
 	}
 }
 
 // Create returns true if the event object owner is a GitTrack
-func (p OwnerIsNotGitTrackPredicate) Create(e event.CreateEvent) bool {
-	return p.ownerIsNotGitTrack(e.Meta.GetOwnerReferences())
+func (p OwnerIsGitTrackPredicate) Create(e event.CreateEvent) bool {
+	return p.ownerIsGitTrack(e.Meta.GetOwnerReferences())
 }
 
 // Update returns true if the event object owner is a GitTrack
-func (p OwnerIsNotGitTrackPredicate) Update(e event.UpdateEvent) bool {
-	return p.ownerIsNotGitTrack(e.MetaNew.GetOwnerReferences())
+func (p OwnerIsGitTrackPredicate) Update(e event.UpdateEvent) bool {
+	return p.ownerIsGitTrack(e.MetaNew.GetOwnerReferences())
 }
 
 // Delete returns true if the event object owner is a GitTrack
-func (p OwnerIsNotGitTrackPredicate) Delete(e event.DeleteEvent) bool {
-	return p.ownerIsNotGitTrack(e.Meta.GetOwnerReferences())
+func (p OwnerIsGitTrackPredicate) Delete(e event.DeleteEvent) bool {
+	return p.ownerIsGitTrack(e.Meta.GetOwnerReferences())
 }
 
 // Generic returns true if the event object owner is a GitTrack
-func (p OwnerIsNotGitTrackPredicate) Generic(e event.GenericEvent) bool {
-	return p.ownerIsNotGitTrack(e.Meta.GetOwnerReferences())
+func (p OwnerIsGitTrackPredicate) Generic(e event.GenericEvent) bool {
+	return p.ownerIsGitTrack(e.Meta.GetOwnerReferences())
 }
 
-func (p OwnerIsNotGitTrackPredicate) ownerIsNotGitTrack(ownerRefs []metav1.OwnerReference) bool {
+func (p OwnerIsGitTrackPredicate) ownerIsGitTrack(ownerRefs []metav1.OwnerReference) bool {
 	for _, ref := range ownerRefs {
 		if ref.Kind == "GitTrack" && ref.APIVersion == farosGroupVersion {
-			return false
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 // OurResponsibilityPredicate returns whether an event is our

--- a/pkg/utils/predicate.go
+++ b/pkg/utils/predicate.go
@@ -46,25 +46,25 @@ func NewOwnerIsNotClusterGitTrackPredicate(client client.Client) OwnerIsNotClust
 
 // Create returns true if the event object owner is a ClusterGitTrack
 func (p OwnerIsNotClusterGitTrackPredicate) Create(e event.CreateEvent) bool {
-	return p.ownerIsClusterGitTrack(e.Meta.GetOwnerReferences())
+	return p.ownerIsNotClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
 // Update returns true if the event object owner is a ClusterGitTrack
 func (p OwnerIsNotClusterGitTrackPredicate) Update(e event.UpdateEvent) bool {
-	return p.ownerIsClusterGitTrack(e.MetaNew.GetOwnerReferences())
+	return p.ownerIsNotClusterGitTrack(e.MetaNew.GetOwnerReferences())
 }
 
 // Delete returns true if the event object owner is a ClusterGitTrack
 func (p OwnerIsNotClusterGitTrackPredicate) Delete(e event.DeleteEvent) bool {
-	return p.ownerIsClusterGitTrack(e.Meta.GetOwnerReferences())
+	return p.ownerIsNotClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
 // Generic returns true if the event object owner is a ClusterGitTrack
 func (p OwnerIsNotClusterGitTrackPredicate) Generic(e event.GenericEvent) bool {
-	return p.ownerIsClusterGitTrack(e.Meta.GetOwnerReferences())
+	return p.ownerIsNotClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
-func (p OwnerIsNotClusterGitTrackPredicate) ownerIsClusterGitTrack(ownerRefs []metav1.OwnerReference) bool {
+func (p OwnerIsNotClusterGitTrackPredicate) ownerIsNotClusterGitTrack(ownerRefs []metav1.OwnerReference) bool {
 	for _, ref := range ownerRefs {
 		if ref.Kind == "ClusterGitTrack" && ref.APIVersion == farosGroupVersion {
 			return false
@@ -88,25 +88,25 @@ func NewOwnerIsNotGitTrackPredicate(client client.Client) OwnerIsNotGitTrackPred
 
 // Create returns true if the event object owner is a GitTrack
 func (p OwnerIsNotGitTrackPredicate) Create(e event.CreateEvent) bool {
-	return p.ownerIsGitTrack(e.Meta.GetOwnerReferences())
+	return p.ownerIsNotGitTrack(e.Meta.GetOwnerReferences())
 }
 
 // Update returns true if the event object owner is a GitTrack
 func (p OwnerIsNotGitTrackPredicate) Update(e event.UpdateEvent) bool {
-	return p.ownerIsGitTrack(e.MetaNew.GetOwnerReferences())
+	return p.ownerIsNotGitTrack(e.MetaNew.GetOwnerReferences())
 }
 
 // Delete returns true if the event object owner is a GitTrack
 func (p OwnerIsNotGitTrackPredicate) Delete(e event.DeleteEvent) bool {
-	return p.ownerIsGitTrack(e.Meta.GetOwnerReferences())
+	return p.ownerIsNotGitTrack(e.Meta.GetOwnerReferences())
 }
 
 // Generic returns true if the event object owner is a GitTrack
 func (p OwnerIsNotGitTrackPredicate) Generic(e event.GenericEvent) bool {
-	return p.ownerIsGitTrack(e.Meta.GetOwnerReferences())
+	return p.ownerIsNotGitTrack(e.Meta.GetOwnerReferences())
 }
 
-func (p OwnerIsNotGitTrackPredicate) ownerIsGitTrack(ownerRefs []metav1.OwnerReference) bool {
+func (p OwnerIsNotGitTrackPredicate) ownerIsNotGitTrack(ownerRefs []metav1.OwnerReference) bool {
 	for _, ref := range ownerRefs {
 		if ref.Kind == "GitTrack" && ref.APIVersion == farosGroupVersion {
 			return false

--- a/pkg/utils/predicate.go
+++ b/pkg/utils/predicate.go
@@ -168,35 +168,35 @@ func (p OwnerIsGitTrackPredicate) ownerIsGitTrack(ownerRefs []metav1.OwnerRefere
 	return false
 }
 
-// OwnersOwnerIsGitTrackPredicate filters events to check the owner's owner of the event
-// object is a GitTrack
+// OwnersOwnerIsGitTrackPredicate filters events to check that the
+// owner of the event object's owner is a GitTrack
 type OwnersOwnerIsGitTrackPredicate struct {
 	client client.Client
 }
 
-// NewOwnersOwnerIsGitTrackPredicate constructs a new OwnerIsGitTrackPredicate
+// NewOwnersOwnerIsGitTrackPredicate constructs a new OwnersOwnerIsGitTrackPredicate
 func NewOwnersOwnerIsGitTrackPredicate(client client.Client) OwnersOwnerIsGitTrackPredicate {
 	return OwnersOwnerIsGitTrackPredicate{
 		client: client,
 	}
 }
 
-// Create returns true if the event object owner's owner is a GitTrack
+// Create returns true if the owner of the event object's owner is a GitTrack
 func (p OwnersOwnerIsGitTrackPredicate) Create(e event.CreateEvent) bool {
 	return p.ownersOwnerIsGitTrack(e.Meta.GetOwnerReferences())
 }
 
-// Update returns true if the event object owner's owner is a GitTrack
+// Update returns true if the owner of the event object's owner is a GitTrack
 func (p OwnersOwnerIsGitTrackPredicate) Update(e event.UpdateEvent) bool {
 	return p.ownersOwnerIsGitTrack(e.MetaNew.GetOwnerReferences())
 }
 
-// Delete returns true if the event object owner's owner is a GitTrack
+// Delete returns true if the owner of the event object's owner is a GitTrack
 func (p OwnersOwnerIsGitTrackPredicate) Delete(e event.DeleteEvent) bool {
 	return p.ownersOwnerIsGitTrack(e.Meta.GetOwnerReferences())
 }
 
-// Generic returns true if the event object owner's owner is a GitTrack
+// Generic returns true if the owner of the event object's owner is a GitTrack
 func (p OwnersOwnerIsGitTrackPredicate) Generic(e event.GenericEvent) bool {
 	return p.ownersOwnerIsGitTrack(e.Meta.GetOwnerReferences())
 }
@@ -241,14 +241,14 @@ func (p OwnersOwnerIsGitTrackPredicate) ownersOwnerIsGitTrack(ownerRefs []metav1
 	return false
 }
 
-// OwnersOwnerIsClusterGitTrackPredicate filters events to check the owner's owner of the event
-// object is a ClusterGitTrack
+// OwnersOwnerIsClusterGitTrackPredicate filters events to check that the
+// owner of the event object's owner is a ClusterGitTrack
 type OwnersOwnerIsClusterGitTrackPredicate struct {
 	client            client.Client
 	includeNamespaced bool
 }
 
-// NewOwnersOwnerIsClusterGitTrackPredicate constructs a new OwnerIsClusterGitTrackPredicate
+// NewOwnersOwnerIsClusterGitTrackPredicate constructs a new OwnersOwnerIsClusterGitTrackPredicate
 func NewOwnersOwnerIsClusterGitTrackPredicate(client client.Client, includeNamespaced bool) OwnersOwnerIsClusterGitTrackPredicate {
 	return OwnersOwnerIsClusterGitTrackPredicate{
 		client:            client,
@@ -256,22 +256,22 @@ func NewOwnersOwnerIsClusterGitTrackPredicate(client client.Client, includeNames
 	}
 }
 
-// Create returns true if the event object owner's owner is a ClusterGitTrack
+// Create returns true if the owner of the event object's owner is a ClusterGitTrack
 func (p OwnersOwnerIsClusterGitTrackPredicate) Create(e event.CreateEvent) bool {
 	return p.ownersOwnerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
-// Update returns true if the event object owner's owner is a ClusterGitTrack
+// Update returns true if the owner of the event object's owner is a ClusterGitTrack
 func (p OwnersOwnerIsClusterGitTrackPredicate) Update(e event.UpdateEvent) bool {
 	return p.ownersOwnerIsClusterGitTrack(e.MetaNew.GetOwnerReferences())
 }
 
-// Delete returns true if the event object owner's owner is a ClusterGitTrack
+// Delete returns true if the owner of the event object's owner is a ClusterGitTrack
 func (p OwnersOwnerIsClusterGitTrackPredicate) Delete(e event.DeleteEvent) bool {
 	return p.ownersOwnerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }
 
-// Generic returns true if the event object owner's owner is a ClusterGitTrack
+// Generic returns true if the owner of the event object's owner is a ClusterGitTrack
 func (p OwnersOwnerIsClusterGitTrackPredicate) Generic(e event.GenericEvent) bool {
 	return p.ownersOwnerIsClusterGitTrack(e.Meta.GetOwnerReferences())
 }
@@ -294,7 +294,7 @@ func (p OwnersOwnerIsClusterGitTrackPredicate) ownersOwnerIsClusterGitTrack(owne
 		if ref.APIVersion != farosGroupVersion {
 			continue
 		}
-		// ClusterGitTrackObjects can only be owned by ClusterGitTracks, so we
+		// ClusterGitTrackObjects can only be owned by ClusterGitTracks, so
 		// if we're owned by a CGTO, then we know that our owners owner is a ClusterGitTrack
 		if ref.Kind == "ClusterGitTrackObject" {
 			return true


### PR DESCRIPTION
This makes it so that gittrackobjects and clustergittrackobjects that are not our responsibility according to the flags doesn't get reconciled by us